### PR TITLE
chore: Sync with rhiza

### DIFF
--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -123,5 +123,5 @@ files:
 - docs/TESTS.md
 - pytest.ini
 - ruff.toml
-synced_at: '2026-04-12T08:01:41Z'
+synced_at: '2026-04-13T00:58:37Z'
 strategy: merge


### PR DESCRIPTION
## 🔄 Template Synchronization

This PR synchronizes the repository with the [jebel-quant/rhiza](https://github.com/jebel-quant/rhiza) template.

### 📊 Change Summary

- **0** files added
- **1** files modified
- **0** files deleted

### 📁 Changes by Category

#### Rhiza Configuration

<details>
<summary>Modified (1)</summary>

- 📝 `.rhiza/template.lock`

</details>

---

**🤖 Generated by [rhiza](https://github.com/jebel-quant/rhiza-cli)**

- Template: `jebel-quant/rhiza@main`
- Last sync: 2026-04-12T12:02:12+04:00
- Sync date: 2026-04-13T00:58:38.162925+00:00