### PR TITLE
Chore: sync Rhiza template v0.19.3 → v0.19.4

### DIFF
--- a/.github/workflows/rhiza_benchmark.yml
+++ b/.github/workflows/rhiza_benchmark.yml
@@ -20,5 +20,5 @@ on:
 
 jobs:
   benchmark:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v0.19.3
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v0.19.4
     secrets: inherit

--- a/.github/workflows/rhiza_book.yml
+++ b/.github/workflows/rhiza_book.yml
@@ -6,7 +6,10 @@
 #          It combines API documentation, test coverage reports, test results, and
 #          interactive notebooks into a single GitHub Pages site.
 #
-# Trigger: This workflow runs on every push to the main or master branch
+# Trigger: This workflow runs on every push (any branch), so every commit
+#          validates that the book still builds. The reusable workflow deploys
+#          to GitHub Pages only from the repository's default branch and never
+#          from a fork; other branches build and upload an artifact only.
 #
 # Components:
 #   - 📓 Process Marimo notebooks
@@ -19,15 +22,14 @@ name: "(RHIZA) BOOK"
 on:
   push:
     branches:
-      - main
-      - master
+      - '**'
 
 permissions:
   contents: read
 
 jobs:
   book:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v0.19.3
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v0.19.4
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -26,5 +26,5 @@ on:
 
 jobs:
   ci:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v0.19.3
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v0.19.4
     secrets: inherit

--- a/.github/workflows/rhiza_codeql.yml
+++ b/.github/workflows/rhiza_codeql.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   codeql:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v0.19.3
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v0.19.4
     secrets: inherit
     permissions:
       security-events: write   # Upload CodeQL results to code scanning

--- a/.github/workflows/rhiza_devcontainer.yml
+++ b/.github/workflows/rhiza_devcontainer.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   devcontainer:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_devcontainer.yml@v0.19.3
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_devcontainer.yml@v0.19.4
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_docker.yml
+++ b/.github/workflows/rhiza_docker.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   docker:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_docker.yml@v0.19.3
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_docker.yml@v0.19.4
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_fuzzing.yml
+++ b/.github/workflows/rhiza_fuzzing.yml
@@ -34,7 +34,7 @@ permissions:
 
 jobs:
   fuzzing:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_fuzzing.yml@v0.19.3
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_fuzzing.yml@v0.19.4
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_marimo.yml
+++ b/.github/workflows/rhiza_marimo.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   marimo:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v0.19.3
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v0.19.4
     secrets: inherit

--- a/.github/workflows/rhiza_mutation.yml
+++ b/.github/workflows/rhiza_mutation.yml
@@ -42,7 +42,7 @@ jobs:
     # this repo sets the `MUTATION_ENABLED` variable to 'true'. Gating here in
     # the caller keeps it optional regardless of the pinned reusable workflow.
     if: ${{ vars.MUTATION_ENABLED == 'true' }}
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_mutation.yml@v0.19.3
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_mutation.yml@v0.19.4
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_release.yml
+++ b/.github/workflows/rhiza_release.yml
@@ -221,7 +221,7 @@ jobs:
           version: "0.11.16"
 
       - name: Configure git auth for private packages
-        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v0.19.3
+        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v0.19.4
         with:
           token: ${{ secrets.GH_PAT }}
 

--- a/.github/workflows/rhiza_scorecard.yml
+++ b/.github/workflows/rhiza_scorecard.yml
@@ -36,7 +36,7 @@ permissions: read-all
 
 jobs:
   scorecard:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v0.19.3
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v0.19.4
     secrets: inherit
     permissions:
       security-events: write   # Upload the SARIF results to code scanning

--- a/.github/workflows/rhiza_sync.yml
+++ b/.github/workflows/rhiza_sync.yml
@@ -35,7 +35,7 @@ on:
 
 jobs:
   sync:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_sync.yml@v0.19.3
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_sync.yml@v0.19.4
     with:
       direct: ${{ github.event_name == 'push' }}
       create-pr: ${{ github.event_name != 'push' && (github.event_name == 'schedule' || inputs.create-pr == true) }}

--- a/.github/workflows/rhiza_weekly.yml
+++ b/.github/workflows/rhiza_weekly.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   weekly:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v0.19.3
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v0.19.4
     secrets: inherit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,12 @@
 # This file is part of the jebel-quant/rhiza repository
 # (https://github.com/jebel-quant/rhiza).
 #
+# Pin node so pre-commit provisions a compatible runtime instead of using the
+# system node. Some npm-based hooks (markdownlint-cli) pull transitive deps that
+# reject odd-numbered current node releases (e.g. v25), failing on EBADENGINE.
+default_language_version:
+  node: "24.12.0"
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
@@ -25,7 +31,7 @@ repos:
         pass_filenames: false
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.15.17'
+    rev: 'v0.15.18'
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix, --unsafe-fixes ]
@@ -34,7 +40,7 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.48.0
+    rev: v0.49.0
     hooks:
       - id: markdownlint
         args: ["--disable", "MD013"]
@@ -76,7 +82,7 @@ repos:
       - id: betterleaks
 
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.11.21
+    rev: 0.11.23
     hooks:
       - id: uv-lock
 
@@ -88,7 +94,7 @@ repos:
         files: ^src/
 
   - repo: https://github.com/Jebel-Quant/rhiza-hooks
-    rev: v0.6.2  # Use the latest release
+    rev: v0.6.3  # Use the latest release
     hooks:
       # Migrated from rhiza
       - id: check-rhiza-workflow-names

--- a/.rhiza/make.d/bootstrap.mk
+++ b/.rhiza/make.d/bootstrap.mk
@@ -111,4 +111,4 @@ clean: ## Clean project artifacts and stale local branches
 
 	@git fetch --prune
 
-	@git branch -vv | awk '/: gone]/{print $$1}' | xargs -r git branch -D
+	@git branch -vv | awk '/: gone]/ && $$1 != "*" && $$1 != "+" {print $$1}' | xargs -r git branch -D

--- a/.rhiza/make.d/marimo.mk
+++ b/.rhiza/make.d/marimo.mk
@@ -1,6 +1,14 @@
 ## Makefile.marimo - Marimo notebook targets
 # This file is included by the main Makefile
 
+# Contribute the marimo notebook folder to the shared deptry scan defined in
+# quality.mk. DEP004 (misplaced development dependency) is ignored because
+# notebooks legitimately import packages declared as development dependencies.
+ifneq ($(wildcard $(MARIMO_FOLDER)),)
+DEPTRY_FOLDERS += $(MARIMO_FOLDER)
+DEPTRY_IGNORE += --ignore DEP004
+endif
+
 # Declare phony targets (they don't produce files)
 .PHONY: marimo-validate marimo
 

--- a/.rhiza/make.d/quality.mk
+++ b/.rhiza/make.d/quality.mk
@@ -10,17 +10,23 @@ LICENSE_FAIL_ON ?= GPL;LGPL;AGPL
 ##@ Quality and Formatting
 all: fmt deptry test docs-coverage security license typecheck rhiza-test ## run all CI targets locally
 
-deptry: install-uv ## Run deptry
-	@if [ -d ${SOURCE_FOLDER} ]; then \
-		$(UVX_BIN) -p ${PYTHON_VERSION} deptry ${SOURCE_FOLDER}; \
-	fi
+# deptry scans one or more folders for dependency issues. Each feature bundle
+# contributes the folders it owns to DEPTRY_FOLDERS (and any per-folder ignores
+# to DEPTRY_IGNORE), so this core target never needs to know which bundles are
+# present. Core itself contributes SOURCE_FOLDER when it exists; see e.g.
+# marimo.mk for a bundle that appends its own folder.
+DEPTRY_FOLDERS ?=
+DEPTRY_IGNORE ?=
+ifneq ($(wildcard $(SOURCE_FOLDER)),)
+DEPTRY_FOLDERS += $(SOURCE_FOLDER)
+endif
 
-	@if [ -d ${MARIMO_FOLDER} ]; then \
-		if [ -d ${SOURCE_FOLDER} ]; then \
-			$(UVX_BIN) -p ${PYTHON_VERSION} deptry ${MARIMO_FOLDER} ${SOURCE_FOLDER} --ignore DEP004; \
-		else \
-		  	$(UVX_BIN) -p ${PYTHON_VERSION} deptry ${MARIMO_FOLDER} --ignore DEP004; \
-		fi \
+deptry: install-uv ## Run deptry over the folders contributed by each bundle
+	@if [ -n "$(strip $(DEPTRY_FOLDERS))" ]; then \
+		printf "${BLUE}[INFO] Running deptry on:${RESET} $(strip $(DEPTRY_FOLDERS))\n"; \
+		$(UVX_BIN) -p ${PYTHON_VERSION} deptry $(strip $(DEPTRY_FOLDERS) $(DEPTRY_IGNORE)); \
+	else \
+		printf "${YELLOW}[WARN] no deptry folders found, skipping.${RESET}\n"; \
 	fi
 
 fmt: install-uv ## check the pre-commit hooks and the linting

--- a/.rhiza/make.d/test.mk
+++ b/.rhiza/make.d/test.mk
@@ -16,38 +16,58 @@ COVERAGE_FAIL_UNDER ?= 90
 ##@ Development and Testing
 
 # The 'test' target runs the complete test suite.
-# 1. Cleans up any previous test results in _tests/.
+# 1. Cleans up any previous test results in _tests/ and stale coverage data.
 # 2. Creates directories for HTML coverage and test reports.
 # 3. Invokes pytest via the local virtual environment.
 # 4. Generates terminal output, HTML coverage, JSON coverage, and HTML test reports.
+#
+# Parallel (pytest-xdist) runs occasionally crash *during worker/session
+# teardown* even though every test passed — e.g. the xdist
+# `worker_workerfinished` KeyError or a pytest-html report-write race. pytest
+# signals these runner-internal crashes with exit code 3 (INTERNALERROR),
+# which is distinct from real test failures (1), interruptions (2) and usage
+# errors (4). We therefore retry the suite once on exit code 3 only, so a
+# teardown race no longer flips a green run red, while genuine failures still
+# fail immediately. Stale `.coverage*` data is removed before each attempt so a
+# previously crashed run cannot leave a corrupt data file that reports a false
+# 0% coverage on the next run.
 test:: install ## run all tests
-	@rm -rf _tests;
-
-	if [ -z "$$(find ${TESTS_FOLDER} -name 'test_*.py' -o -name '*_test.py' 2>/dev/null)" ]; then \
+	@rm -rf _tests
+	@if [ -z "$$(find ${TESTS_FOLDER} -name 'test_*.py' -o -name '*_test.py' 2>/dev/null)" ]; then \
 	  printf "${YELLOW}[WARN] No test files found in ${TESTS_FOLDER}, skipping tests.${RESET}\n"; \
 	  exit 0; \
 	fi; \
-	mkdir -p _tests/html-coverage _tests/html-report; \
 	if [ -d ${SOURCE_FOLDER} ]; then \
-	  ${UV_BIN} run pytest \
-	  -n auto \
-	  --ignore=${TESTS_FOLDER}/benchmarks \
-	  --ignore=${TESTS_FOLDER}/stress \
-	  --cov=${SOURCE_FOLDER} \
-	  --cov-report=term \
-	  --cov-report=html:_tests/html-coverage \
-	  --cov-fail-under=$(COVERAGE_FAIL_UNDER) \
-	  --cov-report=json:_tests/coverage.json \
-	  --cov-report=xml:_tests/coverage.xml \
-	  --html=_tests/html-report/report.html; \
+	  set -- -n auto \
+	    --ignore=${TESTS_FOLDER}/benchmarks \
+	    --ignore=${TESTS_FOLDER}/stress \
+	    --cov=${SOURCE_FOLDER} \
+	    --cov-report=term \
+	    --cov-report=html:_tests/html-coverage \
+	    --cov-fail-under=$(COVERAGE_FAIL_UNDER) \
+	    --cov-report=json:_tests/coverage.json \
+	    --cov-report=xml:_tests/coverage.xml \
+	    --html=_tests/html-report/report.html; \
 	else \
 	  printf "${YELLOW}[WARN] Source folder ${SOURCE_FOLDER} not found, running tests without coverage${RESET}\n"; \
-	  ${UV_BIN} run pytest \
-	  -n auto \
-	  --ignore=${TESTS_FOLDER}/benchmarks \
-	  --ignore=${TESTS_FOLDER}/stress \
-	  --html=_tests/html-report/report.html; \
-	fi
+	  set -- -n auto \
+	    --ignore=${TESTS_FOLDER}/benchmarks \
+	    --ignore=${TESTS_FOLDER}/stress \
+	    --html=_tests/html-report/report.html; \
+	fi; \
+	attempt=1; max_attempts=2; \
+	while :; do \
+	  rm -f .coverage .coverage.* _tests/coverage.xml _tests/coverage.json 2>/dev/null || true; \
+	  mkdir -p _tests/html-coverage _tests/html-report; \
+	  ${UV_BIN} run pytest "$$@"; status=$$?; \
+	  if [ $$status -ne 3 ]; then exit $$status; fi; \
+	  if [ $$attempt -ge $$max_attempts ]; then \
+	    printf "${RED}[ERROR] pytest reported an internal (teardown) error after %s attempts; failing.${RESET}\n" "$$attempt"; \
+	    exit $$status; \
+	  fi; \
+	  printf "${YELLOW}[WARN] pytest exited 3 (xdist/teardown internal error, all tests may have passed); retrying suite (attempt %s/%s)...${RESET}\n" "$$((attempt + 1))" "$$max_attempts"; \
+	  attempt=$$((attempt + 1)); \
+	done
 
 # The 'typecheck' target runs static type analysis using ty and mypy.
 # 1. Builds a list of existing Python source folders to check.

--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -1,7 +1,7 @@
-sha: 99827da43cc32c135388641897fede359dfce4a4
+sha: 7fceeb67cbede92474ec7798b0f2945d844b8b3e
 repo: jebel-quant/rhiza
 host: github
-ref: v0.19.3
+ref: v0.19.4
 include: []
 exclude: []
 templates:
@@ -115,5 +115,5 @@ files:
 - ruff.toml
 profiles:
 - github-project
-synced_at: '2026-06-17T10:30:29Z'
+synced_at: '2026-06-23T03:56:33Z'
 strategy: merge

--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -1,5 +1,5 @@
 repository: "jebel-quant/rhiza"
-ref: "v0.19.3"
+ref: "v0.19.4"
 
 profiles:
   - github-project

--- a/.rhiza/tests/api/test_make_variable_overrides.py
+++ b/.rhiza/tests/api/test_make_variable_overrides.py
@@ -22,13 +22,6 @@ from api.conftest import run_make, strip_ansi
 class TestCoverageFailUnder:
     """COVERAGE_FAIL_UNDER controls the pytest --cov-fail-under threshold."""
 
-    def test_default_threshold_is_90(self, logger) -> None:
-        """Default COVERAGE_FAIL_UNDER value must be 90."""
-        proc = run_make(logger, ["test"])
-        assert "--cov-fail-under=90" in proc.stdout, (
-            "Default coverage threshold should be 90; got:\n" + proc.stdout[:500]
-        )
-
     def test_threshold_override_to_100(self, logger) -> None:
         """COVERAGE_FAIL_UNDER=100 must propagate to pytest invocation."""
         proc = run_make(logger, ["test", "COVERAGE_FAIL_UNDER=100"])
@@ -135,6 +128,22 @@ class TestSourceFolderVariable:
 
         proc = run_make(logger, ["deptry", "SOURCE_FOLDER=mypackage"])
         assert "mypackage" in proc.stdout, "deptry should reference SOURCE_FOLDER; got:\n" + proc.stdout[:400]
+
+    def test_deptry_accumulates_marimo_and_source_in_one_call(self, logger, tmp_path) -> None:
+        """The marimo bundle must contribute its folder (and DEP004 ignore) to the single deptry scan.
+
+        This locks in the accumulator design: each bundle appends to DEPTRY_FOLDERS /
+        DEPTRY_IGNORE rather than the core target hard-coding knowledge of marimo.
+        """
+        (tmp_path / "mypackage").mkdir(exist_ok=True)
+        (tmp_path / "notebooks").mkdir(exist_ok=True)
+
+        proc = run_make(logger, ["deptry", "SOURCE_FOLDER=mypackage", "MARIMO_FOLDER=notebooks"])
+        out = strip_ansi(proc.stdout)
+        # marimo.mk is included before quality.mk, so its folder is appended first.
+        assert "deptry notebooks mypackage --ignore DEP004" in out, (
+            "deptry should scan marimo + source folders in a single call with DEP004 ignored; got:\n" + out[:600]
+        )
 
 
 class TestUvNoModifyPath:

--- a/.rhiza/tests/api/test_makefile_api.py
+++ b/.rhiza/tests/api/test_makefile_api.py
@@ -249,17 +249,18 @@ def test_global_variable_override(logger, setup_api_env):
 
     This tests the pattern documented in CUSTOMIZATION.md:
     Set variables before the include line to override defaults.
-    """
-    # Add variable override to root Makefile (before include line)
-    makefile = setup_api_env / "Makefile"
-    original = makefile.read_text()
-    new_content = (
-        """# Override default coverage threshold (defaults to 90)
-COVERAGE_FAIL_UNDER := 42
-export COVERAGE_FAIL_UNDER
 
-"""
-        + original
+    The Makefile is rebuilt from a pristine root (just the override and the
+    Rhiza include) rather than prepended to the consuming project's own
+    Makefile, so a coverage override the project itself sets cannot shadow the
+    value under test.
+    """
+    makefile = setup_api_env / "Makefile"
+    new_content = (
+        "# Override default coverage threshold (defaults to 90)\n"
+        "COVERAGE_FAIL_UNDER := 42\n"
+        "export COVERAGE_FAIL_UNDER\n\n"
+        "include .rhiza/rhiza.mk\n"
     )
     makefile.write_text(new_content)
 

--- a/.rhiza/tests/integration/test_test_mk.py
+++ b/.rhiza/tests/integration/test_test_mk.py
@@ -1,6 +1,123 @@
-"""Integration test for .rhiza/make.d/test.mk to verify that it handles the case of missing test files correctly."""
+"""Integration tests for .rhiza/make.d/test.mk.
+
+Covers the missing-test-files short circuit plus the parallel-teardown
+robustness behaviour (retry on pytest exit code 3, no retry on real failures,
+stale coverage cleanup) added for issues #1256 and #1257.
+"""
+
+from pathlib import Path
 
 from test_utils import run_make
+
+# A stand-in for `uv` that records each invocation and exits with the next code
+# from FAKE_EXIT_CODES (space-separated, last value repeats). Lets the tests
+# drive the test.mk retry loop deterministically without invoking real pytest.
+FAKE_UV_SCRIPT = r"""#!/bin/sh
+count_file="$FAKE_COUNT_FILE"
+n=$(cat "$count_file" 2>/dev/null || echo 0)
+n=$((n + 1))
+printf '%s' "$n" > "$count_file"
+i=0
+code=0
+for c in $FAKE_EXIT_CODES; do
+  i=$((i + 1))
+  code=$c
+  [ "$i" -ge "$n" ] && break
+done
+echo "fake-uv invocation $n -> exit $code (args: $*)"
+exit "$code"
+"""
+
+# Minimal Makefile that exercises the `test` target in isolation: real test.mk,
+# mocked install, fake uv, and the colour/path variables the recipe expects.
+_TEST_MAKEFILE = r"""
+YELLOW := \033[33m
+RED := \033[31m
+RESET := \033[0m
+
+TESTS_FOLDER := tests
+SOURCE_FOLDER := src
+UV_BIN := {uv_bin}
+
+install:
+	@echo "Mock install"
+
+include .rhiza/make.d/test.mk
+"""
+
+
+def _setup_test_target(git_repo: Path) -> Path:
+    """Wire up the fake uv and a non-empty tests folder; return the invocation-count file."""
+    uv_bin = git_repo / "fake-uv"
+    uv_bin.write_text(FAKE_UV_SCRIPT, encoding="utf-8")
+    uv_bin.chmod(0o755)
+
+    (git_repo / "Makefile").write_text(_TEST_MAKEFILE.format(uv_bin=uv_bin), encoding="utf-8")
+
+    tests_dir = git_repo / "tests"
+    tests_dir.mkdir(exist_ok=True)
+    (tests_dir / "test_placeholder.py").write_text("def test_ok():\n    assert True\n", encoding="utf-8")
+
+    count_file = git_repo / "uv_invocations"
+    return count_file
+
+
+def _run_test_target(logger, count_file: Path, exit_codes: str):
+    """Run `make test` with the fake uv configured to return ``exit_codes``."""
+    import os
+
+    env = os.environ.copy()
+    env["FAKE_EXIT_CODES"] = exit_codes
+    env["FAKE_COUNT_FILE"] = str(count_file)
+    return run_make(logger, ["test"], check=False, dry_run=False, env=env)
+
+
+def test_retry_on_internal_error_then_passes(git_repo, logger):
+    """Exit code 3 (xdist/teardown internal error) is retried once and a clean rerun passes (#1256)."""
+    count_file = _setup_test_target(git_repo)
+    result = _run_test_target(logger, count_file, "3 0")
+
+    assert result.returncode == 0, f"retry should recover a teardown crash; got {result.returncode}\n{result.stdout}"
+    assert count_file.read_text() == "2", "pytest should have been invoked exactly twice (initial + one retry)"
+    assert "retrying suite" in result.stdout
+
+
+def test_persistent_internal_error_fails(git_repo, logger):
+    """A repeated exit code 3 fails after the bounded retry rather than looping forever.
+
+    make collapses any recipe failure to its own exit code 2, so the propagated
+    pytest exit code is asserted via the ``Error 3`` line make prints to stderr.
+    """
+    count_file = _setup_test_target(git_repo)
+    result = _run_test_target(logger, count_file, "3 3 3")
+
+    assert result.returncode != 0, "persistent internal error must fail the target"
+    assert "Error 3" in result.stderr, f"recipe should propagate pytest exit 3; stderr:\n{result.stderr}"
+    assert count_file.read_text() == "2", "retry must be bounded to two attempts total"
+    assert "internal (teardown) error" in result.stdout
+
+
+def test_real_failure_is_not_retried(git_repo, logger):
+    """A genuine test failure (exit 1) fails immediately without a retry, so flaky tests are not masked."""
+    count_file = _setup_test_target(git_repo)
+    result = _run_test_target(logger, count_file, "1 0")
+
+    assert result.returncode != 0, "a real test failure must fail the target"
+    assert "Error 1" in result.stderr, f"recipe should propagate pytest exit 1 unretried; stderr:\n{result.stderr}"
+    assert count_file.read_text() == "1", "pytest should have been invoked exactly once on a real failure"
+    assert "retrying suite" not in result.stdout
+
+
+def test_stale_coverage_is_removed_before_run(git_repo, logger):
+    """A corrupt .coverage left by a previous crashed run is cleaned before pytest runs (#1257)."""
+    count_file = _setup_test_target(git_repo)
+    stale = git_repo / ".coverage"
+    stale.write_text("corrupt-not-a-sqlite-db", encoding="utf-8")
+
+    result = _run_test_target(logger, count_file, "0")
+
+    assert result.returncode == 0, result.stdout
+    assert not stale.exists(), "stale .coverage must be removed before the run to avoid a false 0% coverage"
 
 
 def test_missing_tests_warning(git_repo, logger):

--- a/.rhiza/tests/structure/test_pyproject.py
+++ b/.rhiza/tests/structure/test_pyproject.py
@@ -116,7 +116,7 @@ class TestProjectFields:
 class TestProjectUrls:
     """Tests for [project.urls] — Homepage and Repository links."""
 
-    @pytest.fixture(scope="class")
+    @pytest.fixture
     def urls(self, project: dict) -> dict:
         """Return the [project.urls] table."""
         table = project.get("urls")
@@ -142,7 +142,7 @@ class TestProjectUrls:
 class TestProjectClassifiers:
     """Tests for [project].classifiers — Python version and licence entries."""
 
-    @pytest.fixture(scope="class")
+    @pytest.fixture
     def classifiers(self, project: dict) -> list[str]:
         """Return the classifiers list."""
         cl = project.get("classifiers", [])
@@ -166,7 +166,7 @@ class TestProjectClassifiers:
 class TestDependencyGroups:
     """Tests for [dependency-groups] — ensures required groups are declared."""
 
-    @pytest.fixture(scope="class")
+    @pytest.fixture
     def dependency_groups(self, pyproject: dict) -> dict:
         """Return the [dependency-groups] table."""
         dg = pyproject.get("dependency-groups")
@@ -193,7 +193,7 @@ class TestDependencyGroups:
 class TestGitTagVersion:
     """Tests for harmony between the latest git tag and pyproject.toml version."""
 
-    @pytest.fixture(scope="class")
+    @pytest.fixture
     def latest_tag(self, root: Path) -> str:
         """Return the latest semver git tag, or skip if none exist."""
         result = subprocess.run(  # nosec B603

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,6 +9,13 @@ log_cli_date_format = %H:%M:%S
 # Show extra summary info for skipped/failed tests
 addopts = -ra
 timeout = 60
+# Treat the class-scoped-instance-method fixture deprecation as an error so it
+# cannot silently regress. Matched by message rather than by warning category:
+# the category name is version-specific (PytestRemovedIn9Warning vs ...In10Warning)
+# and referencing a missing class breaks `--resolution lowest-direct` runs at
+# parse time. Third-party DeprecationWarnings stay non-fatal.
+filterwarnings =
+    error:Class-scoped fixture defined as instance method is deprecated
 # Register custom markers
 markers =
     stress: marks tests as stress tests (deselect with '-m "not stress"')


### PR DESCRIPTION
## Summary

Bumps the Rhiza template pin from **v0.19.3 → v0.19.4** (latest release) and applies the sync. The Rhiza **CLI** pin (`.rhiza/.rhiza-version`) is left at `0.17.6` — already the latest on PyPI.

What's in v0.19.4 (all upstream/managed):
- *(book)* Build on every commit, deploy to Pages only from default branch
- *(make)* Skip worktree/current branches in clean branch-prune
- *(test)* Make parallel test teardown robust to xdist/report races
- *(pre-commit)* Pin node to 24.12.0 so npm hooks survive odd node releases
- Combined renovate dep updates; ruff-pre-commit → v0.15.18; uv-pre-commit → v0.11.23

## Conflict resolution

**None.** The 3-way merge applied cleanly ("All changes applied cleanly") — zero `*.rej` files, zero conflict markers. 24 files updated, all **Rhiza-managed**: the 13 `.github/workflows/*`, `.pre-commit-config.yaml`, `.rhiza/make.d/{bootstrap,marimo,quality,test}.mk`, several `.rhiza/tests/*`, the refreshed `.rhiza/template.lock`, and `pytest.ini`. No locally-owned files (`ruff.toml`, `pyproject.toml`, `README.md`, `src/`, `tests/`) were touched.

## Quality gates

| Gate | Result |
|------|--------|
| `make fmt` | ✅ PASS |
| `make typecheck` | ✅ PASS (ty + mypy --strict) |
| `make docs-coverage` | ✅ PASS (100%) |
| `make deptry` | ✅ PASS |
| `make security` | ✅ PASS (pip-audit + bandit) |
| `make test` | ✅ PASS (17/17, exit 0; verified deterministic across 3 runs) |

No gate fallout to fix. No upstream Rhiza changes required.

## Notes

- **Mutation workflow config left unset (by request):** `MUTATION_ENABLED` (variable), `GH_PAT` and `UV_EXTRA_INDEX_URL` (secrets) are not configured. The mutation gate is gated on `vars.MUTATION_ENABLED == 'true'`, so it will remain **skipped** until these are set under Settings → Secrets and variables → Actions. (An existing `PAT_TOKEN` secret is unrelated — different name.) Fuzzing needs no configuration.
- **Workflow scope:** this branch updates `.github/workflows/*`, so merging/pushing requires a token with the `workflow` scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
