### PR TITLE
feat: add ClusterFuzzLite fuzzing scaffold for dummypy

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,9 @@
+# ClusterFuzzLite build image for dummypy.
+# Uses the OSS-Fuzz Python base image, which provides Atheris and the
+# compile_python_fuzzer helper.
+# Pinned by SHA256 so the build image only changes through reviewed updates.
+FROM gcr.io/oss-fuzz-base/base-builder-python@sha256:99c714c91ec30778a3ce3ae5b37491a81fc043808bc8f2955159c2f608f80116
+
+COPY . $SRC
+WORKDIR $SRC
+COPY .clusterfuzzlite/build.sh $SRC/build.sh

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -eu
+# ClusterFuzzLite build script — installs dummypy and compiles each Python
+# harness in tests/fuzz/ via OSS-Fuzz's compile_python_fuzzer helper.
+
+cd "$SRC"
+
+# Pin pip so the build environment is reproducible and only changes through a
+# reviewed bump (the same rationale as the SHA-pinned base image).
+pip3 install --upgrade "pip==24.3.1"
+
+# Install the package and its runtime dependencies (numpy, pandas, attrs) into
+# the build environment so PyInstaller can discover and bundle dummypy into each
+# frozen fuzzer binary. Without this, the harness would fail to import dummypy
+# at runtime inside the ClusterFuzzLite runner.
+pip3 install .
+
+for fuzzer in tests/fuzz/fuzz_*.py; do
+  compile_python_fuzzer "$fuzzer"
+done

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -14,6 +14,10 @@ pip3 install --upgrade "pip==24.3.1"
 # at runtime inside the ClusterFuzzLite runner.
 pip3 install .
 
+# PyInstaller does not discover the C-extension submodules of numpy/pandas on
+# its own, so the frozen fuzzer crashes at runtime with
+# "No module named 'numpy._core._exceptions'". --collect-all pulls in every
+# submodule, data file and shared library for these native packages.
 for fuzzer in tests/fuzz/fuzz_*.py; do
-  compile_python_fuzzer "$fuzzer"
+  compile_python_fuzzer "$fuzzer" --collect-all numpy --collect-all pandas
 done

--- a/tests/fuzz/fuzz_grid.py
+++ b/tests/fuzz/fuzz_grid.py
@@ -1,0 +1,45 @@
+"""Fuzz the dummypy ``Grid`` constructor and ``diff()`` against arbitrary sizes.
+
+``Grid`` builds a pair of ``(n+1) x (n+1)`` DataFrames from an integer size and
+``diff()`` returns their element-wise difference. The constructor must never
+crash on adversarial sizes with an unexpected exception — it should either build
+a grid or raise a clean, documented error. This harness exercises that contract
+with coverage-guided input.
+
+Run locally:
+    pip install atheris numpy pandas attrs
+    python tests/fuzz/fuzz_grid.py -atheris_runs=20000
+
+Run in ClusterFuzzLite: this file is built by .clusterfuzzlite/build.sh.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import atheris
+
+with atheris.instrument_imports():
+    from dummypy import Grid
+
+
+def test_one_input(data: bytes) -> None:
+    """Exercise Grid construction and diff() with a fuzzed grid size."""
+    fdp = atheris.FuzzedDataProvider(data)
+    # Bound the size: the grid allocates an (n+1) x (n+1) matrix, so an
+    # unbounded n would trivially exhaust memory without exercising any real
+    # logic. Widen this range to hunt for edge cases (e.g. negative sizes).
+    n = fdp.ConsumeIntInRange(0, 1000)
+
+    grid = Grid(n=n)
+    grid.diff()
+
+
+def main() -> None:
+    """Run the Atheris fuzz loop."""
+    atheris.Setup(sys.argv, test_one_input)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds the opt-in **ClusterFuzzLite** fuzzing scaffold so the existing `rhiza_fuzzing.yml` workflow actually runs.

- `.clusterfuzzlite/Dockerfile` — OSS-Fuzz Python base image, SHA-pinned
- `.clusterfuzzlite/build.sh` — installs `dummypy` and compiles each `tests/fuzz/fuzz_*.py` harness
- `tests/fuzz/fuzz_grid.py` — Atheris harness fuzzing `Grid(n).diff()` over bounded sizes

The `FUZZING_ENABLED` repo variable is already set to `true`; the workflow additionally requires a `.clusterfuzzlite/` config to be present, which this PR provides.

## Test plan
- [x] `python -m py_compile` clean
- [x] Smoke-tested `Grid(n).diff()` for representative sizes against the installed package
- [ ] CI code-change fuzzing run (PR trigger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
