### PR TITLE
Fix: implement payoffs module and correct README inaccuracies (closes #138, #139)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Get started immediately with a fully configured cloud development environment:
 
 ```bash
 # Clone the repository
-git clone git@github.com:[USERNAME]/dummypy.git
-cd dummypy
+git clone git@github.com:markrichardson/dummyrepo.git
+cd dummyrepo
 
 # Run the automated setup
 make setup
@@ -63,8 +63,13 @@ make clean         # Clean up environment
 ```python
 import dummypy as dp
 
+# Build a grid and compute element-wise differences
 grid = dp.Grid()
 grid.diff()
+
+# Vanilla European option payoffs at expiry
+dp.call_payoff([80.0, 100.0, 130.0], strike=100.0)  # -> [ 0.,  0., 30.]
+dp.put_payoff([70.0, 100.0, 130.0], strike=100.0)   # -> [30.,  0.,  0.]
 ```
 
 ## Development
@@ -80,18 +85,17 @@ This documentation covers:
 
 ## Architecture
 
-- **Core Models** (`dummypy.models`): Example statistical models
-- **Core Payoffs** (`dummypy.payoffs`): Demonstration payoff functions
-- **Analytics** (`dummypy.analytics`): Sample performance tracking and reporting
+- **Grid** (`dummypy.things`): Example grid data structure built on pandas DataFrames
+- **Payoffs** (`dummypy.payoffs`): Vanilla European option payoff functions
 
 ## License
 
-© 2025 Mark Richardson. Released under MIT License.
+© 2026 Mark Richardson. Released under MIT License.
 
 This software is provided for educational and demonstration purposes. Feel free to use, modify, and distribute according to the MIT License terms.
 
 ---
 
-**Version**: 0.1.0
-**Last Updated**: August 2025
-**Classification**: CONFIDENTIAL
+**Version**: 0.1.4
+**Last Updated**: June 2026
+**Classification**: Public (MIT License)

--- a/src/dummypy/__init__.py
+++ b/src/dummypy/__init__.py
@@ -1,5 +1,6 @@
 """DummyPy Analytics Library - A demonstration package for data analytics."""
 
+from .payoffs import call_payoff, put_payoff
 from .things import Grid
 
-__all__ = ["Grid"]
+__all__ = ["Grid", "call_payoff", "put_payoff"]

--- a/src/dummypy/payoffs.py
+++ b/src/dummypy/payoffs.py
@@ -1,1 +1,32 @@
-"""Payoffs module for financial calculations (placeholder)."""
+"""Payoff functions for vanilla European option contracts."""
+
+import numpy as np
+import numpy.typing as npt
+
+
+def call_payoff(spot: npt.ArrayLike, strike: float) -> npt.NDArray[np.float64]:
+    """Return the expiry payoff of a European call option.
+
+    Args:
+        spot: Underlying spot price(s) at expiry. Scalars and array-likes
+            are both accepted.
+        strike: Strike price of the option.
+
+    Returns:
+        Element-wise payoff ``max(spot - strike, 0)`` as a float array.
+    """
+    return np.maximum(np.asarray(spot, dtype=np.float64) - strike, 0.0)
+
+
+def put_payoff(spot: npt.ArrayLike, strike: float) -> npt.NDArray[np.float64]:
+    """Return the expiry payoff of a European put option.
+
+    Args:
+        spot: Underlying spot price(s) at expiry. Scalars and array-likes
+            are both accepted.
+        strike: Strike price of the option.
+
+    Returns:
+        Element-wise payoff ``max(strike - spot, 0)`` as a float array.
+    """
+    return np.maximum(strike - np.asarray(spot, dtype=np.float64), 0.0)

--- a/tests/test_payoffs.py
+++ b/tests/test_payoffs.py
@@ -1,0 +1,61 @@
+"""Unit tests for the vanilla option payoff functions."""
+
+import numpy as np
+import pytest
+
+from dummypy import call_payoff, put_payoff
+
+
+class TestCallPayoff:
+    """Tests for :func:`dummypy.call_payoff`."""
+
+    def test_in_the_money(self):
+        """Call pays spot minus strike when in the money."""
+        assert call_payoff(120.0, 100.0) == pytest.approx(20.0)
+
+    def test_out_of_the_money_floors_at_zero(self):
+        """Call payoff never goes negative."""
+        assert call_payoff(80.0, 100.0) == pytest.approx(0.0)
+
+    def test_at_the_money(self):
+        """Call is worthless at the strike."""
+        assert call_payoff(100.0, 100.0) == pytest.approx(0.0)
+
+    def test_vectorized(self):
+        """Call payoff is computed element-wise over an array of spots."""
+        result = call_payoff([80.0, 100.0, 130.0], 100.0)
+        np.testing.assert_allclose(result, [0.0, 0.0, 30.0])
+
+    def test_returns_float_array(self):
+        """Integer inputs are promoted to a float array."""
+        result = call_payoff([120, 90], 100)
+        assert result.dtype == np.float64
+
+
+class TestPutPayoff:
+    """Tests for :func:`dummypy.put_payoff`."""
+
+    def test_in_the_money(self):
+        """Put pays strike minus spot when in the money."""
+        assert put_payoff(80.0, 100.0) == pytest.approx(20.0)
+
+    def test_out_of_the_money_floors_at_zero(self):
+        """Put payoff never goes negative."""
+        assert put_payoff(120.0, 100.0) == pytest.approx(0.0)
+
+    def test_at_the_money(self):
+        """Put is worthless at the strike."""
+        assert put_payoff(100.0, 100.0) == pytest.approx(0.0)
+
+    def test_vectorized(self):
+        """Put payoff is computed element-wise over an array of spots."""
+        result = put_payoff([70.0, 100.0, 130.0], 100.0)
+        np.testing.assert_allclose(result, [30.0, 0.0, 0.0])
+
+
+def test_put_call_parity_at_expiry():
+    """Call - put = spot - strike for every spot at expiry."""
+    spots = [60.0, 100.0, 140.0]
+    strike = 100.0
+    parity = call_payoff(spots, strike) - put_payoff(spots, strike)
+    np.testing.assert_allclose(parity, np.asarray(spots) - strike)


### PR DESCRIPTION
## Summary
Addresses both open quality-assessment issues from the Rhiza scorecard.

### Closes #139 — empty `payoffs.py` placeholder
- Replaced the stub with real vanilla **European call/put payoff functions** (`call_payoff`, `put_payoff`), accepting scalars or array-likes and returning float arrays (numpy-vectorized, fully typed, Google-style docstrings to match `things.py`).
- Exported both from `dummypy.__init__`.
- Added `tests/test_payoffs.py`: ITM/OTM/ATM, vectorized, dtype, and a put-call parity check. Coverage on the module now reflects exercised behavior (no longer trivially-100% empty).

### Closes #138 — README inaccuracies
- **Architecture** section now lists only modules that exist (`dummypy.things`, `dummypy.payoffs`); removed the nonexistent `dummypy.models` / `dummypy.analytics`.
- Version `0.1.0` → `0.1.4` (matches `pyproject.toml`); Last Updated → June 2026.
- Replaced contradictory `Classification: CONFIDENTIAL` with `Public (MIT License)`.
- Fixed clone/`cd` placeholders to the real `markrichardson/dummyrepo`.
- Added a payoff usage example.

## Verification — all Rhiza gates pass
`make fmt`, `make typecheck` (ty + mypy --strict), `make docs-coverage` (100%), `make deptry`, `make test` — **27 passed, 100% coverage**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)