### PR TITLE
docs(readme): fix make targets to match make help (#147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,19 @@ Get started immediately with a fully configured cloud development environment:
 
 ### 💻 Local Development
 
+```bash
+# Clone and enter the repository
+git clone git@github.com:markrichardson/dummyrepo.git
+cd dummyrepo
+
+# Install the development environment
+make install
+
+# Run the test suite and quality checks
+make test
+make fmt
+```
+
 ## Core Features
 
 - **Example Statistical Models**: Sample algorithms & statistics for data analysis
@@ -40,7 +53,7 @@ git clone git@github.com:markrichardson/dummyrepo.git
 cd dummyrepo
 
 # Run the automated setup
-make setup
+make install
 ```
 
 #### Windows Users
@@ -51,10 +64,9 @@ For detailed Windows setup instructions using WSL and VS Code, see **[INSTALL_WI
 
 ```bash
 make help          # Show all available commands
-make setup         # Create development environment
+make install       # Create development environment
 make test          # Run test suite
-make lint          # Run code quality checks
-make format        # Format code
+make fmt           # Run pre-commit hooks and linting
 make clean         # Clean up environment
 ```
 


### PR DESCRIPTION
Closes #147

## Summary
The README documented `make setup`, `make lint`, and `make format`, none of which exist in the Rhiza-managed Makefile. A fresh contributor following the Quick Start hit "No rule to make target".

- Replaced `make setup` -> `make install` (Installation & Setup + Available Commands).
- Replaced `make lint`/`make format` -> `make fmt`.
- Filled in the previously empty Local Development section with real steps (`make install`, `make test`, `make fmt`).

Every `make <target>` in the README now resolves to a real target listed by `make help`.

## Gates
- `make fmt`: PASS (markdownlint + all hooks green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)