### PR TITLE
docs(readme): fix Codespaces badge slug dummypy -> dummyrepo (#148)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This software is created for learning and demonstration purposes. Feel free to u
 
 Get started immediately with a fully configured cloud development environment:
 
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/markrichardson/dummypy?quickstart=1)
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/markrichardson/dummyrepo?quickstart=1)
 [![Coverage](https://markrichardson.github.io/dummyrepo/coverage-badge.svg)](https://markrichardson.github.io/dummyrepo/reports/html-coverage/)
 
 **Benefits:**


### PR DESCRIPTION
Closes #148

## Summary
The GitHub Codespaces badge pointed at `markrichardson/dummypy` (the package name), but the repo slug is `dummyrepo`, so the badge 404'd. Changed the slug to `markrichardson/dummyrepo` so the badge opens the repo's Codespaces creation page.

## Gates
- `make fmt`: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)