### PR TITLE
docs(api): add missing API Reference pages (#150)

### DIFF
--- a/docs/api/payoffs.md
+++ b/docs/api/payoffs.md
@@ -1,0 +1,3 @@
+# Payoffs
+
+::: dummypy.payoffs

--- a/docs/api/things.md
+++ b/docs/api/things.md
@@ -1,0 +1,3 @@
+# Things
+
+::: dummypy.things

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,7 @@ plugins:
   - mkdocstrings:
       handlers:
         python:
+          paths: [src]
           options:
             docstring_style: google
             show_source: true


### PR DESCRIPTION
Closes #150

## Summary
`mkdocs.yml` nav referenced `api/payoffs.md` and `api/things.md`, but `docs/api/` did not exist, so the published book's API Reference section was broken/empty.

- Added `docs/api/payoffs.md` (`::: dummypy.payoffs`) and `docs/api/things.md` (`::: dummypy.things`), matching the existing single-H1 doc-page style.
- Added `paths: [src]` to the mkdocstrings python handler in `mkdocs.yml`. Without it the book build fails with `ModuleNotFoundError: No module named 'dummypy'` because the package uses a `src/` layout and the `uvx`-isolated build env does not have it installed.

## Verification
- `make book`: PASS. Renders `_book/api/payoffs/index.html` and `_book/api/things/index.html` with the `call_payoff`, `put_payoff`, and `Grid` symbols. No dead-link warnings for the api pages (the only 2 remaining build warnings are pre-existing dead links in `development/VSCODE_EXTENSIONS.md`, unrelated to this change and not in the nav).
- `make fmt`: PASS (markdownlint + yaml).

🤖 Generated with [Claude Code](https://claude.com/claude-code)