### PR TITLE
feat: expose importable __version__ on dummypy package

### DIFF
--- a/src/dummypy/__init__.py
+++ b/src/dummypy/__init__.py
@@ -1,6 +1,13 @@
 """DummyPy Analytics Library - A demonstration package for data analytics."""
 
+from importlib.metadata import PackageNotFoundError, version
+
 from .payoffs import call_payoff, put_payoff
 from .things import Grid
 
-__all__ = ["Grid", "call_payoff", "put_payoff"]
+try:
+    __version__ = version("dummypy")
+except PackageNotFoundError:  # pragma: no cover - package not installed
+    __version__ = "0.0.0"
+
+__all__ = ["Grid", "__version__", "call_payoff", "put_payoff"]

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,16 @@
+"""Tests for the importable package version."""
+
+from importlib.metadata import version
+
+import dummypy
+
+
+def test_version_is_exposed():
+    """``dummypy.__version__`` is a non-empty string."""
+    assert isinstance(dummypy.__version__, str)
+    assert dummypy.__version__
+
+
+def test_version_matches_installed_metadata():
+    """``dummypy.__version__`` matches the installed package metadata."""
+    assert dummypy.__version__ == version("dummypy")


### PR DESCRIPTION
Closes #159

Exposes an importable `__version__` on the `dummypy` package, derived from the installed package metadata via `importlib.metadata.version`. `pyproject.toml` [project].version remains the single source of truth, so the three copies (pyproject, README, runtime) can no longer drift — the same staleness class that produced #149.

Changes:
- src/dummypy/__init__.py: add `__version__` (metadata-derived, with a safe fallback when the package is not installed) and include it in `__all__`
- tests/test_version.py: assert `__version__` is a non-empty string and matches the installed metadata

Gates: `make fmt`, `make test` green; coverage stays at 100%.

from rhiza_quality re-assessment

🤖 Generated with [Claude Code](https://claude.com/claude-code)