### PR TITLE
chore: update rhiza to v1.0.0

### DIFF
--- a/.github/workflows/rhiza_benchmark.yml
+++ b/.github/workflows/rhiza_benchmark.yml
@@ -20,5 +20,5 @@ on:
 
 jobs:
   benchmark:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.0.0
     secrets: inherit

--- a/.github/workflows/rhiza_book.yml
+++ b/.github/workflows/rhiza_book.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   book:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.0.0
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -26,5 +26,5 @@ on:
 
 jobs:
   ci:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.0.0
     secrets: inherit

--- a/.github/workflows/rhiza_codeql.yml
+++ b/.github/workflows/rhiza_codeql.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   codeql:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.0.0
     secrets: inherit
     permissions:
       security-events: write   # Upload CodeQL results to code scanning

--- a/.github/workflows/rhiza_devcontainer.yml
+++ b/.github/workflows/rhiza_devcontainer.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   devcontainer:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_devcontainer.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_devcontainer.yml@v1.0.0
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_docker.yml
+++ b/.github/workflows/rhiza_docker.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   docker:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_docker.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_docker.yml@v1.0.0
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_fuzzing.yml
+++ b/.github/workflows/rhiza_fuzzing.yml
@@ -34,7 +34,7 @@ permissions:
 
 jobs:
   fuzzing:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_fuzzing.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_fuzzing.yml@v1.0.0
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_marimo.yml
+++ b/.github/workflows/rhiza_marimo.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   marimo:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.0.0
     secrets: inherit

--- a/.github/workflows/rhiza_mutation.yml
+++ b/.github/workflows/rhiza_mutation.yml
@@ -42,7 +42,7 @@ jobs:
     # this repo sets the `MUTATION_ENABLED` variable to 'true'. Gating here in
     # the caller keeps it optional regardless of the pinned reusable workflow.
     if: ${{ vars.MUTATION_ENABLED == 'true' }}
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_mutation.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_mutation.yml@v1.0.0
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_release.yml
+++ b/.github/workflows/rhiza_release.yml
@@ -221,7 +221,7 @@ jobs:
           version: "0.11.16"
 
       - name: Configure git auth for private packages
-        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v0.19.9
+        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v1.0.0
         with:
           token: ${{ secrets.GH_PAT }}
 

--- a/.github/workflows/rhiza_scorecard.yml
+++ b/.github/workflows/rhiza_scorecard.yml
@@ -36,7 +36,7 @@ permissions: read-all
 
 jobs:
   scorecard:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.0.0
     secrets: inherit
     permissions:
       security-events: write   # Upload the SARIF results to code scanning

--- a/.github/workflows/rhiza_sync.yml
+++ b/.github/workflows/rhiza_sync.yml
@@ -35,7 +35,7 @@ on:
 
 jobs:
   sync:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_sync.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_sync.yml@v1.0.0
     with:
       direct: ${{ github.event_name == 'push' }}
       create-pr: ${{ github.event_name != 'push' && (github.event_name == 'schedule' || inputs.create-pr == true) }}

--- a/.github/workflows/rhiza_weekly.yml
+++ b/.github/workflows/rhiza_weekly.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   weekly:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.0.0
     secrets: inherit

--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -1,7 +1,7 @@
-sha: ff7bd135efaaad8aadf01d41bb60dd8419c015ae
+sha: 3186f09ecffa95a44148fbae02bc90d9e9dd05e2
 repo: jebel-quant/rhiza
 host: github
-ref: v0.19.9
+ref: v1.0.0
 include: []
 exclude: []
 templates:
@@ -120,5 +120,5 @@ files:
 - ruff.toml
 profiles:
 - github-project
-synced_at: '2026-06-28T13:14:43Z'
+synced_at: '2026-06-29T05:27:37Z'
 strategy: merge

--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -1,5 +1,5 @@
 repository: "jebel-quant/rhiza"
-ref: "v0.19.9"
+ref: "v1.0.0"
 
 profiles:
   - github-project


### PR DESCRIPTION
## Summary

- Bumps the template `ref` to `v1.0.0` in `.rhiza/template.yml` (was `v0.19.9`)
- Runs `make sync` to apply upstream template changes — applied cleanly via 3-way merge, no conflicts
- Touches 13 `rhiza_*.yml` workflows + `.rhiza/template.lock`

## Quality gates

All gates run against the synced `v1.0.0` state. Bare `make <target>`, cheapest first.

| Gate | Result | Notes |
|------|--------|-------|
| `make fmt` | ✅ PASS | All pre-commit hooks pass; no auto-fixes needed |
| `make typecheck` | ✅ PASS | `ty` + `mypy --strict` clean (7 source files) |
| `make docs-coverage` | ✅ PASS | interrogate 100.0% (310/310) |
| `make deptry` | ✅ PASS | No dependency issues |
| `make security` | ✅ PASS | pip-audit: 0 vulnerabilities; bandit clean |
| `make validate` | ✅ PASS | template.yml valid; `ref: v1.0.0` valid; src/ + tests/ present |
| `make test` | ✅ PASS | 174 passed, 1 skipped (by-design doctest skip), coverage 100% (gate 90%) |

**Verdict: clean bump — all gates green.**

## Scorecard (1–10)

Scoped to locally-owned items only. Rhiza-managed files (`.github/workflows/*`, `Makefile`, `.rhiza/*`, `.pre-commit-config.yaml`, `pytest.ini`, `ruff.toml`) are flagged upstream/out-of-scope and do not drive the marks.

| Subcategory | Score | Justification | To raise |
|-------------|-------|---------------|----------|
| Linting / style | 10 | `make fmt` fully green; ruff format + check clean | — |
| Type safety | 10 | mypy --strict + ty clean over `src/` | — |
| Documentation | 10 | docstring coverage 100% over locally-owned `src/` | — |
| Dependency & security hygiene | 10 | deptry clean; pip-audit 0 vulns; bandit clean | — |
| Test pass rate | 10 | 174 passed, only a by-design skip | — |
| Test coverage & depth | 7 | Reported coverage (100%) is measured over `.rhiza/utils` (Rhiza-owned). Local `src/dummypy` (`payoffs.py`, `things.py`) is exercised by `tests/` but is **not** in the `--cov` scope, so local coverage is unmeasured | Point `COVERAGE_FAIL_UNDER`/cov scope at `src/dummypy` so local code coverage is actually gated |
| Code structure & readability | 8 | `src/dummypy` is small and clean; layout standard. Minimal surface limits a higher mark | Grow real modules with focused responsibilities as the package matures |
| CI / tooling health | n/a | Driven by Rhiza-managed workflows/Makefile — upstream/out-of-scope | Fixed upstream in `jebel-quant/rhiza` |

**Overall: 9/10.** Clean, well-gated repo; the v0.19.9 → v1.0.0 bump introduced no regressions.

**Highest-leverage improvement:** the coverage gate measures `.rhiza/utils` (synced, upstream-owned) rather than the locally-owned `src/dummypy`. Repointing the coverage source folder at `src/dummypy` would make the 90% gate actually protect this repo's own code.

### Recommendations (in-scope only)

1. **Gate coverage on local source** — Test coverage & depth 7→10. Set the coverage source folder to `src/dummypy` (custom-env.mk / pyproject) so `make test` measures and enforces coverage on locally-owned code. *Done when:* `make test` reports `src/dummypy` line coverage and fails below the threshold.

_Recommendations only — no code changed beyond the version bump + sync._

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
