### PR TITLE
docs: describe actual API in README instead of non-existent features

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-DummyPy is a Python analytics library created for educational and testing purposes. This toolkit provides example statistical modeling, data analysis, and visualization capabilities designed to showcase modern Python development practices.
+DummyPy is a small Python analytics library created for educational and testing purposes. It provides a pandas-backed `Grid` data structure and a set of vanilla European option payoff functions, designed to showcase modern Python development practices.
 
 **📚 EDUCATIONAL & DEMONSTRATION PURPOSE**
 This software is created for learning and demonstration purposes. Feel free to use, modify, and distribute.
@@ -39,9 +39,8 @@ make fmt
 
 ## Core Features
 
-- **Example Statistical Models**: Sample algorithms & statistics for data analysis
-- **Data Processing**: Demonstration of data manipulation and analysis techniques
-- **Visualization Tools**: Example plotting and data visualization capabilities
+- **Grid** (`dummypy.Grid`): A pandas-backed grid data structure with validated sizing and an element-wise `diff()` method.
+- **Option payoffs** (`dummypy.call_payoff`, `dummypy.put_payoff`): Vanilla European call and put payoff functions at expiry, working on scalars or array-likes.
 
 ## Installation & Setup
 


### PR DESCRIPTION
## Summary

The README's Overview and Core Features sections advertised features the package does not ship — "Example Statistical Models", "Data Processing", and "Visualization Tools". The actual public API is the pandas-backed `Grid` and the vanilla European option payoff functions.

This rewrites both sections to describe only what `dummypy` actually exports.

## Changes
- **Overview**: now describes the `Grid` data structure and option payoff functions.
- **Core Features**: replaced the three fictional bullets with the two real feature groups, each tied to its exported symbol (`Grid`, `call_payoff`, `put_payoff`).

## Acceptance criterion
Every feature named in the README maps to a symbol exported from `dummypy` (`__all__ = ["Grid", "__version__", "call_payoff", "put_payoff"]`). No stale feature claims remain. `make fmt` passes clean (markdownlint + README-sync hook).

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)