### PR TITLE
test: lock coverage at 100% and add Grid property-based tests (closes #176, #177)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,12 @@ LOGO_FILE=.rhiza/assets/rhiza-logo.svg
 # Override template default: include mkdocstrings plugin for API docs
 MKDOCS_EXTRA_PACKAGES = --with 'mkdocstrings[python]'
 
+# Lock the coverage gate at 100% (src/ is fully covered). Set here in the
+# repo-owned Makefile (not the non-committed local.mk) so a regression below
+# 100% fails `make test` for everyone. Beats the template's `?= 90` default
+# because this assignment precedes the `include` below.
+COVERAGE_FAIL_UNDER = 100
+
 # Always include the Rhiza API (template-managed)
 include .rhiza/rhiza.mk
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dev = [
 
 test = [
     "pytest>=9.1.1",
+    "hypothesis>=6.156",
 ]
 
 lint = [

--- a/tests/test_things.py
+++ b/tests/test_things.py
@@ -43,6 +43,8 @@ The test suite covers:
 import numpy as np
 import pandas as pd
 import pytest
+from hypothesis import given
+from hypothesis import strategies as st
 
 from dummypy import Grid
 
@@ -248,6 +250,41 @@ class TestGridValidation:
         """Grid(n=0) remains valid (boundary case)."""
         grid = Grid(n=0)
         assert grid.n == 0
+
+
+class TestGridProperties:
+    """Property-based tests asserting Grid invariants across a range of ``n``.
+
+    Where the fixture-based tests above pin behaviour at a handful of fixed
+    sizes, these use hypothesis to generate many ``n`` and assert the
+    invariants that must hold for every valid grid.
+    """
+
+    @given(n=st.integers(min_value=0, max_value=30))
+    def test_shape_is_n_plus_one_square(self, n):
+        """Both x and y are square with side n+1 for any non-negative n."""
+        grid = Grid(n=n)
+        assert grid.x.shape == (n + 1, n + 1)
+        assert grid.y.shape == (n + 1, n + 1)
+
+    @given(n=st.integers(min_value=0, max_value=30))
+    def test_x_is_transpose_of_y(self, n):
+        """X is always the transpose of y."""
+        grid = Grid(n=n)
+        pd.testing.assert_frame_equal(grid.x, grid.y.T)
+
+    @given(n=st.integers(min_value=0, max_value=30))
+    def test_diff_equals_x_minus_y(self, n):
+        """diff() equals the element-wise x - y for any n."""
+        grid = Grid(n=n)
+        pd.testing.assert_frame_equal(grid.diff(), grid.x - grid.y)
+
+    @given(n=st.integers(min_value=0, max_value=30))
+    def test_diff_is_antisymmetric(self, n):
+        """diff() is antisymmetric: diff == -diff.T for any n."""
+        grid = Grid(n=n)
+        diff = grid.diff()
+        pd.testing.assert_frame_equal(diff, -diff.T)
 
 
 # Integration tests

--- a/uv.lock
+++ b/uv.lock
@@ -259,6 +259,7 @@ notebook = [
     { name = "loman" },
 ]
 test = [
+    { name = "hypothesis" },
     { name = "pytest" },
 ]
 
@@ -276,7 +277,10 @@ dev = [
 ]
 lint = [{ name = "ruff", specifier = ">=0.15.20" }]
 notebook = [{ name = "loman", specifier = ">=0.6.0" }]
-test = [{ name = "pytest", specifier = ">=9.1.1" }]
+test = [
+    { name = "hypothesis", specifier = ">=6.156" },
+    { name = "pytest", specifier = ">=9.1.1" },
+]
 
 [[package]]
 name = "fonttools"
@@ -334,6 +338,65 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "hypothesis"
+version = "6.156.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/52/22ec531bcc61d55b6858b15c176c9d3284d6447c8618f17e90ca174e8bcf/hypothesis-6.156.4.tar.gz", hash = "sha256:38deb10b31ba18dfdbf9f6803711720148cea5e493a298dfb187c2fe72456791", size = 476287, upload-time = "2026-07-08T21:55:29.786Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/b2/6ab1506f7540c689916af0ab89c15413656001c991b0da6256b51e54706e/hypothesis-6.156.4-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:ba523e6ab93ee51f933ebab5bb62dadfd20762922b93e9f48b31655f1343fbd2", size = 748213, upload-time = "2026-07-08T21:54:01.971Z" },
+    { url = "https://files.pythonhosted.org/packages/da/d6/d8c44fa442c767d8f2d582da8f5e9efb6719416a1276ed1b61cc70cc7bb8/hypothesis-6.156.4-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:eb225cfab4553913f3bbd535c688ffa684c70432810a0b50555bd8cf70dbdd09", size = 743036, upload-time = "2026-07-08T21:54:55.678Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/68/e99a04ec397f8e9d921249c9fb95c40f3842e889e9de4cbfc5ce77ebee03/hypothesis-6.156.4-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eb061eefe1c25a2b3432b2d801f4931510bddc4a6f10c6b23f0c0d8215262bf7", size = 1070425, upload-time = "2026-07-08T21:55:19.511Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/12/f36f487d2adc08bc0f3159a9083857f1dcfc7f44e76142e56d0f35427202/hypothesis-6.156.4-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3250aa89a3cfacdf601c86d8eafa4a47161e05062afe851a2650d5c6c5fc8a4d", size = 1120438, upload-time = "2026-07-08T21:55:27.882Z" },
+    { url = "https://files.pythonhosted.org/packages/58/d4/e93daa5124d90a43fd2b9ebcbcdd84995b91368c859e4eff4bbf0555bccf/hypothesis-6.156.4-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:60ceff7f4a058eeec032e7ad4e18aeff58860cd5819a88db78b0a49ccce25cc4", size = 1244772, upload-time = "2026-07-08T21:55:03.568Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/48/c77d590fef2888e18abce5de6ba2b022981deb97d175a4e1dffbe35997d1/hypothesis-6.156.4-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7ebada1b9ec964600a68e05a289abd8ee12edde02abc92653783f03346abfa5e", size = 1287496, upload-time = "2026-07-08T21:53:57.7Z" },
+    { url = "https://files.pythonhosted.org/packages/83/18/861ea8097074f99a532439bce6873abfec66d11c4eb727fb2277189afa40/hypothesis-6.156.4-cp310-abi3-win_amd64.whl", hash = "sha256:d0d82e00b61a3866d97cbb43dce54532e352f93bf7f0600b3f1d00a7f24a88f5", size = 640374, upload-time = "2026-07-08T21:54:06.509Z" },
+    { url = "https://files.pythonhosted.org/packages/85/a0/138ac58f597537e531be90cdcc4ef830514bb8fab2756c236c8d37c76730/hypothesis-6.156.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:c6f5e041118701df743c561e22008d1eeecb5305e03291d8a3d3468946a9be5d", size = 749182, upload-time = "2026-07-08T21:53:52.13Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/33/3fb125a988d35464fccc120be644a74e8dcc80e2b532a9413f257c68cc03/hypothesis-6.156.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ce644bf50fc3fec1ca4b993618ece303c7036a3cd833b26b33392a3134dd7070", size = 743700, upload-time = "2026-07-08T21:54:36.016Z" },
+    { url = "https://files.pythonhosted.org/packages/88/08/1ed0e5ec6a8126468345fe4419e6d502025358184bc9428e7f3d772e3b7e/hypothesis-6.156.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77687165ad9fe324112ff098e598b5483c467840f2594feae47ce0e71ba12ff6", size = 1070978, upload-time = "2026-07-08T21:55:05.304Z" },
+    { url = "https://files.pythonhosted.org/packages/24/1a/a45b4288ba88bfa3df02501fe06db505ee7a0e17cc724907be2b6af96996/hypothesis-6.156.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f3ac237d1377e201398d5c81aed0dfca85ecb47538f5df477b27f968123d917", size = 1120668, upload-time = "2026-07-08T21:55:21.627Z" },
+    { url = "https://files.pythonhosted.org/packages/84/50/20265f6419a802ff26c7b6fdb3f1e655d18330695ffb68d7ded976eb65a0/hypothesis-6.156.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c3dd6e9847b738c12d1b9878f7eb6cba5970aec5e30de148aa510c6bdab3d617", size = 1245253, upload-time = "2026-07-08T21:54:29.599Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/57/7cdb87a3d83fbdd1ec38b8fe0c333ba731906b56480544b899af9c2c0e3b/hypothesis-6.156.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:aaa4aa4045e0f7e542af06812feb241af71107b77f73a7e7599d6f70af358f18", size = 1287885, upload-time = "2026-07-08T21:54:34.48Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/b4/a1a6d21b89ce5b5a79b72a9898c61f33816072f0309c6da332bd9a5ebf31/hypothesis-6.156.4-cp311-cp311-win_amd64.whl", hash = "sha256:5b9a53b9c40dff7e6b97d4b0535576c8662dcf42315abc75deb5d190269c574e", size = 640181, upload-time = "2026-07-08T21:54:04.932Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/3b/2f56c1aaa07586897feaac36a07ef68bedca4a410b796e5e0f77ecee0003/hypothesis-6.156.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f6958df0438cf9115fb880afaa9f02fb1ebcbefc763c4c374737ad4ca3f11cae", size = 749016, upload-time = "2026-07-08T21:54:23.132Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/d1/d6b77e95a2cf5b572805491c53cb2c45eec0e7dff65c2310457d6537ad0f/hypothesis-6.156.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ad091a3110fd5c4731251068c049a48fb33a9ef01f5901b88a81c68ab70c943b", size = 741911, upload-time = "2026-07-08T21:55:25.836Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/d3/229fdb1dac8dc1c103f95f3d128df3c63c07630778178cf42fbb2dd7376b/hypothesis-6.156.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:15de4176d0365c9855898f75cf2986be6f361643c08f0d1bc154a89779a9cb89", size = 1069810, upload-time = "2026-07-08T21:54:57.762Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/e1/03be6105682766e090cc6355f09fd461dfb473d952f8f07c2dff3d0fd74e/hypothesis-6.156.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:19b70642500369f70743321e03359d2504e5f4d62cfd0046054867f79965d8bb", size = 1119552, upload-time = "2026-07-08T21:54:28.114Z" },
+    { url = "https://files.pythonhosted.org/packages/88/3e/80ad5a0db03e7f07b07c8b1064cdf169695f09f68a3c62b03ae68e687c79/hypothesis-6.156.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7b7232c9ea9f947b6b5b1c317ac9ce988af2fbb076fa5a4836ff8e1d20f1b176", size = 1243862, upload-time = "2026-07-08T21:54:52.276Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/4c/af9661cabb126b8432c43996c925f8c4d174745d61616c8f00e7b6cc08ea/hypothesis-6.156.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bedc54bb398eaf54b9e1d88744c89b559fc8bf165c3e603f821cc53754ade241", size = 1286422, upload-time = "2026-07-08T21:54:39.323Z" },
+    { url = "https://files.pythonhosted.org/packages/40/a8/c9c8e506122cb6cfc634b07ab0d7e8db7d5d51e27d9b937e20d61e1a272e/hypothesis-6.156.4-cp312-cp312-win_amd64.whl", hash = "sha256:b4217076cb7169fc17c32b06206c4503ad71d740eed0b3c20023a11f04418179", size = 637645, upload-time = "2026-07-08T21:54:26.268Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/4a/a4e797af1ba0cf8cddba7e460294bd25a2d6efc33db898efb288edc993a1/hypothesis-6.156.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:2c799aee207d5ecf5af2fbf86250806245618e58cdb41c4606718a9ed001c706", size = 749445, upload-time = "2026-07-08T21:55:01.697Z" },
+    { url = "https://files.pythonhosted.org/packages/62/02/6c66c992b02aee085b644d0400a75e086ce17c47ff83d7a2e1f48d657d57/hypothesis-6.156.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7af68750ed3ebcf32540e32fe111850fc40e9ba15be2613ef7f04620c51669c", size = 742079, upload-time = "2026-07-08T21:54:43.87Z" },
+    { url = "https://files.pythonhosted.org/packages/79/04/be90e612f4b6e75752f0420d3945893ed0f71a04485867a7ad9c376f161e/hypothesis-6.156.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:32e4c6988898e9e21c97f48b941cf1e10a5ea4f31db82e5722c1bf777d17c3dc", size = 1069972, upload-time = "2026-07-08T21:55:13.584Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/71/6e74917b591c56402f726f4c08bd819d586ea20857a029549541c3808330/hypothesis-6.156.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:07f7207655919eedda6d888ca6cfcf83eeedff3fc34fc6a83aabe197fed4966b", size = 1119967, upload-time = "2026-07-08T21:54:14.468Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/e7/4619e6acdd4eca4b58dd69b036c61a60714741197be4ca7d3eda6ef616e4/hypothesis-6.156.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1db6caf5718eb90dad5d86254961bf2eda319542e9e0479c562327f649c2115b", size = 1244027, upload-time = "2026-07-08T21:54:42.371Z" },
+    { url = "https://files.pythonhosted.org/packages/30/76/3e7b788502e0c9a5ef6830e63e63ae2b3001f213e6ea5313fde75d4bdadb/hypothesis-6.156.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5afdcd0f320dc4b443c51722860a893dcf03a12e5cd17e68143b28461a1c9da2", size = 1286704, upload-time = "2026-07-08T21:55:23.543Z" },
+    { url = "https://files.pythonhosted.org/packages/72/97/46893ce86e106e00bd8224dc85bd6439c1bd24cf513f73e4719926bd8053/hypothesis-6.156.4-cp313-cp313-win_amd64.whl", hash = "sha256:32f63111e79020e530913673c2ef91642fc297ae552364acde00f70d50142b9a", size = 637938, upload-time = "2026-07-08T21:54:03.307Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/ea/f2c4313475f54b55eb160e09fe139b520c1ea77ece9e05a24c8094261e89/hypothesis-6.156.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:a946f12823c004bc02d7cbdc9c2eb1943cb9c7f05c95f014e353d53e9c50ab14", size = 749476, upload-time = "2026-07-08T21:54:40.827Z" },
+    { url = "https://files.pythonhosted.org/packages/66/8b/c364bd4a3504e9c7d895552aa69e4453fa3c2dfa63a4fdf37f97f539b457/hypothesis-6.156.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:bedff9adcf0ad5fd8ce4d6ea5dda29ae316b0856beef4236460020a55ed30020", size = 742306, upload-time = "2026-07-08T21:54:21.53Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/53/1e05b2ffed333628656b5e1cee65f5a8dcca259c5be9221c0817dad74f14/hypothesis-6.156.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:19aaa6c1f6a1d11b40e97ac62a58b5f2e4481e8c8b1ef132b582dd61dcc0e5b4", size = 1070146, upload-time = "2026-07-08T21:54:47.133Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/25c4fd4641497c4f2680ba8d8300c7e8d9c5c8bafea219f597580e587508/hypothesis-6.156.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d058917bdc3c7e575461ba81128d018819061a0291961cf4c90c0c8ed8c21436", size = 1120131, upload-time = "2026-07-08T21:53:55.874Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/18/d59e50d48bfb6697980fc0ff02e3fc1e32a71a4d549a1939be7d90d4b057/hypothesis-6.156.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:bbb5ea5be2f9ee115332a896eb45ab4018aee13a702a4562a29947d7206ef65d", size = 1244302, upload-time = "2026-07-08T21:55:15.549Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/c2/60666d23338fb4e33ff28e87f0579dd16cd99cfe5972448b1b79ec1b96e3/hypothesis-6.156.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2ce314d1dff756be7b0173ab8c72697bbe4c831ed765b8ef6b1aeb0a7056da42", size = 1287215, upload-time = "2026-07-08T21:54:17.549Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/39/24410320c5bddf58d72e3c61da91b56f889279d52dc38a3695662f22255b/hypothesis-6.156.4-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:139b9306e84b8c25c0aef9eec67e096f92fa6557a6088e56e58bdcbd7974f0c4", size = 586424, upload-time = "2026-07-08T21:54:45.356Z" },
+    { url = "https://files.pythonhosted.org/packages/83/9a/e1cf9393b3686ceb23b87d8f7f4c5c3e1f4751b974642439e99b70bb0272/hypothesis-6.156.4-cp314-cp314-win_amd64.whl", hash = "sha256:e65d36b2cfb863a15ab3fd81d5de741df9b51f2b56c5f7ecee637b8e9333938d", size = 637751, upload-time = "2026-07-08T21:54:24.576Z" },
+    { url = "https://files.pythonhosted.org/packages/95/3f/25fa799861ed2c1e32c9064d02ad3090e0f282f2a1efed98d744a4be6970/hypothesis-6.156.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:454b2ea256feda13edd8c9514f2898a949e4f96b0156c67a852cbfe1f777055a", size = 747509, upload-time = "2026-07-08T21:54:11.308Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/ac/a2ec42a5fc0789c6a953c98ee299afd0c6fe80a16c0836e3285697614d0e/hypothesis-6.156.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8db65e17fb1e6dcaf34d4ad69a104d1437409e58178fc752b6344394d0a35f71", size = 740865, upload-time = "2026-07-08T21:54:19.761Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/df/e87653a9a1de9fb838237b7f6b22a76cfa52cb21ba4b98622f2b25c00bac/hypothesis-6.156.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:44af150302f88aec7f0b90566c0f27edb847f0d23cbe729fe75cfe582089366e", size = 1069164, upload-time = "2026-07-08T21:54:08.121Z" },
+    { url = "https://files.pythonhosted.org/packages/58/fc/bf1d6d4e783d163434ec3a5a692588f8deee772538de6cb9cd52417c543e/hypothesis-6.156.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2f7707302553bddf84826a44821055b2ddf460c9199a92bd60f0da8b39b42872", size = 1119203, upload-time = "2026-07-08T21:53:54.321Z" },
+    { url = "https://files.pythonhosted.org/packages/be/f3/b7802b9db8fa6d2caefb143e9a8fe47145ba9ce74e276eb6abd2fd0b0b8c/hypothesis-6.156.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:618e7edf24c9b1d932f0ba835ee5f8571a197143bbaf5467a5c8f180f96494ee", size = 1243073, upload-time = "2026-07-08T21:55:11.703Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/90/70c5605c35c72dddf2be50e88d017e9139ae68e1ac7aaf29dc90732fa8e5/hypothesis-6.156.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ff172915bafafc827981f3bab3bd076ad96e05d108c43a19373ccf3be085c727", size = 1285526, upload-time = "2026-07-08T21:55:07.271Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/43/a4f1b41e410d8bfe78f17eeaac08cee4e326b341345009802e073d20af71/hypothesis-6.156.4-cp314-cp314t-win_amd64.whl", hash = "sha256:0725c7e2c3bd863e75aae8d5be1f650abc9a3774200055461e1142625af9419c", size = 637843, upload-time = "2026-07-08T21:54:12.858Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/ac/c5495b2c4070f80665660cfbc8ee81a1bc3e254565f41d66ecd5c3a4724c/hypothesis-6.156.4-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:6f3bef67bd9ddce33ee9017f05a3670eac2518f27f80a9ab3112ac4d7772f293", size = 749728, upload-time = "2026-07-08T21:54:31.273Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/58/f46decb99415e08d80d915235899cc7e8ba02ee7f9effebc93fcdcd5315b/hypothesis-6.156.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:0ca6a4785c058257a729daa218d9c9d06d05db42da4f52484c590f57f7905d5b", size = 744371, upload-time = "2026-07-08T21:54:50.653Z" },
+    { url = "https://files.pythonhosted.org/packages/44/ec/c8c19542f6389580e6281f87802849754b8910d29e0a7e36e32ac4e18811/hypothesis-6.156.4-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e7338ee15ee84ef994ae3d1a2e71d25c82713bf5ec27f55442755ae15e38369b", size = 1071376, upload-time = "2026-07-08T21:54:54.003Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/10/57cc273baf0cfe722eaa903c72db7ca45e7df4cc0780f80cb5dfe50edbbf/hypothesis-6.156.4-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:539be6819696560c23ff6c0d0af4e7c1ea4936123f4433b511977a79adc371d5", size = 1121429, upload-time = "2026-07-08T21:55:17.323Z" },
+    { url = "https://files.pythonhosted.org/packages/68/cf/4b31c31716980972f7b5dfd75fe11021e9b8b6dd09664cc5a82c8c03c2bc/hypothesis-6.156.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:b1717bc41d1a0683470f950c565ade33a52c28f600b1aa824d74f651a36e2c7b", size = 640761, upload-time = "2026-07-08T21:54:37.716Z" },
 ]
 
 [[package]]
@@ -1271,6 +1334,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Addresses two quality findings from the rhiza-v1.1.2 boost scorecard (#175).

### Closes #176 — Lock test coverage gate at 100%
`src/` is fully covered, but the gate bar defaulted to 90% (`COVERAGE_FAIL_UNDER ?= 90` in the Rhiza-owned `.rhiza/make.d/test.mk`), so a silent regression to 90% would still pass. Set `COVERAGE_FAIL_UNDER = 100` in the **repo-owned** `Makefile` (before the `include`, so it beats the template's `?=`). Chosen over `local.mk` because that file is intentionally not committed.

- **Done when:** `make test` fails on any coverage drop below 100% on `src/`. ✅ Verified — gate output now reads `Required test coverage of 100% reached`.

### Closes #177 — Property-based tests for Grid invariants
Added a `TestGridProperties` class in `tests/test_things.py` using hypothesis to assert `Grid` invariants across generated `n ∈ [0, 30]`:
- shape is `(n+1, n+1)` square
- `x == y.T`
- `diff() == x - y`
- `diff()` is antisymmetric (`diff == -diff.T`)

Declared `hypothesis>=6.156` in the `test` dependency group and relocked `uv.lock` — it was present in the local venv but undeclared, so CI would not have had it.

## Verification
- `make test` → **37 passed** (was 33; 4 new property tests), coverage **100.0%** against the new 100% gate
- `make fmt` → all hooks pass
