### PR TITLE
chore: update rhiza to v1.2.1

### DIFF
--- a/.github/workflows/rhiza_benchmark.yml
+++ b/.github/workflows/rhiza_benchmark.yml
@@ -20,5 +20,5 @@ on:
 
 jobs:
   benchmark:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.2.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.2.1
     secrets: inherit

--- a/.github/workflows/rhiza_book.yml
+++ b/.github/workflows/rhiza_book.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   book:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.2.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.2.1
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -26,5 +26,5 @@ on:
 
 jobs:
   ci:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.2.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.2.1
     secrets: inherit

--- a/.github/workflows/rhiza_codeql.yml
+++ b/.github/workflows/rhiza_codeql.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   codeql:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.2.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.2.1
     secrets: inherit
     permissions:
       security-events: write   # Upload CodeQL results to code scanning

--- a/.github/workflows/rhiza_devcontainer.yml
+++ b/.github/workflows/rhiza_devcontainer.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   devcontainer:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_devcontainer.yml@v1.2.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_devcontainer.yml@v1.2.1
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_docker.yml
+++ b/.github/workflows/rhiza_docker.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   docker:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_docker.yml@v1.2.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_docker.yml@v1.2.1
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_fuzzing.yml
+++ b/.github/workflows/rhiza_fuzzing.yml
@@ -34,7 +34,7 @@ permissions:
 
 jobs:
   fuzzing:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_fuzzing.yml@v1.2.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_fuzzing.yml@v1.2.1
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_marimo.yml
+++ b/.github/workflows/rhiza_marimo.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   marimo:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.2.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.2.1
     secrets: inherit

--- a/.github/workflows/rhiza_mutation.yml
+++ b/.github/workflows/rhiza_mutation.yml
@@ -42,7 +42,7 @@ jobs:
     # this repo sets the `MUTATION_ENABLED` variable to 'true'. Gating here in
     # the caller keeps it optional regardless of the pinned reusable workflow.
     if: ${{ vars.MUTATION_ENABLED == 'true' }}
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_mutation.yml@v1.2.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_mutation.yml@v1.2.1
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_release.yml
+++ b/.github/workflows/rhiza_release.yml
@@ -222,7 +222,7 @@ jobs:
           version: "0.11.16"
 
       - name: Configure git auth for private packages
-        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v1.2.0
+        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v1.2.1
         with:
           token: ${{ secrets.GH_PAT }}
 

--- a/.github/workflows/rhiza_scorecard.yml
+++ b/.github/workflows/rhiza_scorecard.yml
@@ -36,7 +36,7 @@ permissions: read-all
 
 jobs:
   scorecard:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.2.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.2.1
     secrets: inherit
     permissions:
       security-events: write   # Upload the SARIF results to code scanning

--- a/.github/workflows/rhiza_weekly.yml
+++ b/.github/workflows/rhiza_weekly.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   weekly:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.2.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.2.1
     secrets: inherit

--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -1,7 +1,7 @@
-sha: 7a906d2cf8c33d1d870ca7c7f5af3127f070c3ed
+sha: e0fe02300840e39fe75d19db2741e9a790f87794
 repo: jebel-quant/rhiza
 host: github
-ref: v1.2.0
+ref: v1.2.1
 include: []
 exclude: []
 templates:
@@ -87,5 +87,5 @@ files:
 - docs/mkdocs-base.yml
 - pytest.ini
 - ruff.toml
-synced_at: '2026-07-16T14:21:19Z'
+synced_at: '2026-07-17T12:36:50Z'
 strategy: merge

--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -1,5 +1,5 @@
 repository: "jebel-quant/rhiza"
-ref: "v1.2.0"
+ref: "v1.2.1"
 
 profiles:
   - github-project


### PR DESCRIPTION
## Summary
- Bumps the template `ref` to `v1.2.1` in `.rhiza/template.yml`
- Platform profile: `github-project` (unchanged — already matches the GitHub origin)
- Runs the bundled `scripts/sync.py` to apply upstream template changes; conflicts resolved taking upstream (12 workflow files, 1 line each)

## Quality gates

| Gate | Result |
|------|--------|
| `make fmt` (pre-commit + ruff + markdownlint + bandit + actionlint) | ✅ PASS |
| `make typecheck` (ty + mypy --strict over `src/`) | ✅ PASS |
| `make docs-coverage` (interrogate) | ✅ PASS — 100.0% |
| `make deptry` | ✅ PASS — no dependency issues |
| `make security` (bandit) | ✅ PASS — no findings |
| `make validate` | ⚪ N/A — target not present in template v1.2.1 (upstream/out-of-scope) |
| `make test` (pytest + coverage gate) | ✅ PASS — 45 passed, 100.0% coverage (gate: 100%) |
| Test-layout parity | ✅ PASS — tests mirror sources 1:1 |

## Scorecard (locally-owned scope: `src/`, `tests/`, `pyproject.toml`, `README.md`, `.rhiza/template.yml`)

| Subcategory | Score | Justification |
|-------------|:-----:|---------------|
| Linting / style | 10 | All pre-commit + ruff hooks pass |
| Type safety | 10 | `ty` and `mypy --strict` clean over 3 source files |
| Docstring / API-doc coverage | 10 | interrogate 100% |
| Test pass rate | 10 | 45/45 passing |
| Test coverage & depth | 10 | 100% on `src/`; suite includes property-style tests (put-call parity, antisymmetry, monotonicity, non-negativity) |
| Test design quality | 10 | Tests assert behaviour/invariants, not implementation; validator error paths covered |
| Dependency & security hygiene | 10 | deptry clean; bandit no findings |
| Error handling | 10 | `_check_n`/`_check_strike` validators raise typed `ValueError`/`TypeError` |
| Public API / semver | 10 | `__init__` re-exports a tight surface (`Grid`, `call_payoff`, `put_payoff`); CHANGELOG maintained |
| Code complexity | 10 | radon avg CC A (1.875); worst block A; MI all A (65.0–100.0) |
| Overall architecture | 10 | `grid.py`/`payoffs.py` independent leaf modules; `__init__` composes; no import cycles, correct layering |
| User-facing documentation | 10 | README present and validated by fmt gate (runs README code fragments) |

**Overall: 10/10.** Template fidelity (`make validate` drift) is upstream/out-of-scope for this template version — the sync applied cleanly with conflicts resolved to the upstream side.

**Highest-leverage improvement:** none required — the locally-owned surface is at ceiling. Keep coverage at 100% and the 1:1 test-layout parity as `src/` grows.
