### PR TITLE
chore(pyproject): modernize Python version and license metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "dummypy"
 version = "0.1.5"
 description = "A dummy Python analytics library for demonstration purposes."
 authors = [{ name = "Mark Richardson", email = "mrichardson82@gmail.com" }]
-license = { text = "MIT" }
+license = "MIT"
 readme = "README.md"
 requires-python = ">=3.11"
 keywords = ["dummypy", "analytics", "demo", "example"]
@@ -17,7 +17,6 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,10 @@ requires-python = ">=3.11"
 keywords = ["dummypy", "analytics", "demo", "example"]
 classifiers = [
     "Private :: Do Not Upload",
-    "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Development Status :: 3 - Alpha",


### PR DESCRIPTION
Modernizes the `[project]` metadata in `pyproject.toml`.

**Python versions** — one explicit trove classifier per supported version instead of the generic `Programming Language :: Python :: 3` rows. `requires-python` is 3.11", so the classifiers are: **3.11,3.12,3.13,3.14**.

**License** — dropped the `License :: ...` classifiers, which PEP 639 deprecates in favour of the `license` SPDX expression plus `license-files`. Backends implementing PEP 639 reject a project that declares both.

**SPDX** — moved the `license` key from the deprecated table form to a PEP 639 SPDX expression.

Metadata only — no source, dependency, or tooling changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
