### PR TITLE
fix!: mark Grid immutability as breaking, document it in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ make clean         # Clean up environment
 A pandas-backed grid of coordinate frames. `x` is the transpose of `y`, and
 `diff()` returns their element-wise difference as a fresh frame on each call.
 
+Instances are **immutable**. `x` and `y` are derived from `n`, so allowing any of
+the three to be reassigned would break the invariants set at construction — build a
+new `Grid` instead of mutating one.
+
 ```python
 from dummypy import Grid
 
@@ -84,6 +88,7 @@ grid.x.shape               # -> (4, 4)
 grid.diff().loc["2", "1"]  # -> 1   (x - y at those coordinates)
 
 # Grid(n=-1) raises ValueError: Grid size n must be non-negative
+# grid.n = 5 raises FrozenInstanceError: Grid is immutable, build a new one
 ```
 
 ### `call_payoff` / `put_payoff`


### PR DESCRIPTION
Closes #203
Closes #204

## #203 — the breaking-change marker

`Grid` becoming frozen is a breaking API change, but it landed as a plain `fix:`
(`edac915`). `git-cliff` sets `commit.breaking` only from a `!` on the type or a
`BREAKING CHANGE:` footer, and `cliff.toml:38` renders `[**breaking**]` only when that
flag is set — so the change was listed under "Bug Fixes" with no warning.

**Hand-editing `CHANGELOG.md` would not have worked.** `cliff.toml` drives
`uvx git-cliff --output CHANGELOG.md`, which regenerates the file wholesale, and the
release flow folds a *freshly generated* changelog into the bump commit. A hand-written
note would be silently discarded. The marker has to come from git history — the
generator's only input.

This branch therefore carries an annotating commit (`fix!:` + `BREAKING CHANGE:`
footer) with no code change; the behaviour already shipped in `edac915`. Rewriting that
merged commit would mean force-pushing the default branch, which is not worth it for a
changelog annotation.

**Verified** — `uvx git-cliff --unreleased` before:

```
### Bug Fixes
- Make Grid immutable so n, x and y cannot desynchronise
```

after:

```
### Bug Fixes
- Make Grid immutable so n, x and y cannot desynchronise
- [**breaking**] Grid is immutable — n, x and y can no longer be reassigned
```

### The version bump is not in this PR — deliberately

`.rhiza/tests/test_pyproject.py::TestGitTagVersion` asserts the latest git tag matches
`[project].version`. The latest tag is **v0.1.5** and the version is **0.1.5**, so
bumping to `0.2.0` here would fail `make rhiza-test` until a matching tag exists —
and tagging is the release flow's job, which bumps and tags atomically (hence
`commit = false` / `tag = false` in `[tool.bumpversion]`).

So the remaining step is a release-time action, not a file edit:

```bash
bump-my-version bump minor      # 0.1.5 -> 0.2.0, not 0.1.6
```

The `[**breaking**]` marker this PR adds is what makes that the visibly correct choice.

## #204 — README documents immutability

The Usage section documented `Grid(n=-1)` raising `ValueError` but said nothing about
instances being frozen — the one behaviour that changed for existing users. Adds the
`FrozenInstanceError` line in the same comment idiom, plus a sentence on why
immutability holds (`x` and `y` are derived from `n`).

The added line is a **comment**, not a live statement: `.rhiza/tests/test_readme.py`
and `test_readme_validation.py` execute and syntax-check these blocks, so a real
raising statement would fail validation.

## Verification

| Gate | Result |
|---|---|
| `make fmt` | PASS — nothing rewritten |
| `make rhiza-test` | PASS — 39 passed, 1 skipped |
| `uvx git-cliff --unreleased` | `[**breaking**]` renders |

`make test` was not re-run: the only file changed is `README.md`, and `src/`/`tests/`
are untouched since the suite last passed 50/50 at 100% coverage on `main`.
