### PR TITLE
fix(payoffs): reject non-finite strikes instead of returning inf

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ grid.diff().loc["2", "1"]  # -> 1   (x - y at those coordinates)
 
 Vanilla European option payoffs at expiry. Both accept a scalar or an
 array-like of spots and return a `float64` NumPy array; an invalid `strike`
-(negative or NaN) raises a `ValueError`.
+(negative, NaN or infinite) raises a `ValueError`.
 
 ```python
 from dummypy import call_payoff, put_payoff

--- a/src/dummypy/payoffs.py
+++ b/src/dummypy/payoffs.py
@@ -11,16 +11,19 @@ def _check_strike(strike: float) -> None:
 
     Mirrors the validation style of :func:`dummypy.grid._check_n`: fail fast
     with an actionable message rather than silently producing a meaningless
-    payoff.
+    payoff. Infinities are rejected alongside NaN: an unchecked infinite
+    strike does not fail, it silently yields an infinite put payoff, which
+    is exactly the meaningless result this validator exists to prevent.
 
     Args:
         strike: The proposed strike price.
 
     Raises:
-        ValueError: If ``strike`` is NaN or negative.
+        ValueError: If ``strike`` is not finite (NaN or infinite), or is
+            negative.
     """
-    if math.isnan(strike):
-        msg = "strike must be a real number, got NaN"
+    if not math.isfinite(strike):
+        msg = f"strike must be a finite real number, got {strike}"
         raise ValueError(msg)
     if strike < 0:
         msg = f"strike must be non-negative, got {strike}"
@@ -33,13 +36,15 @@ def call_payoff(spot: npt.ArrayLike, strike: float) -> npt.NDArray[np.float64]:
     Args:
         spot: Underlying spot price(s) at expiry. Scalars and array-likes
             are both accepted.
-        strike: Strike price of the option. Must be a non-negative real number.
+        strike: Strike price of the option. Must be a finite, non-negative
+            real number.
 
     Returns:
         Element-wise payoff ``max(spot - strike, 0)`` as a float array.
 
     Raises:
-        ValueError: If ``strike`` is NaN or negative.
+        ValueError: If ``strike`` is not finite (NaN or infinite), or is
+            negative.
     """
     _check_strike(strike)
     return np.maximum(np.asarray(spot, dtype=np.float64) - strike, 0.0)
@@ -51,13 +56,15 @@ def put_payoff(spot: npt.ArrayLike, strike: float) -> npt.NDArray[np.float64]:
     Args:
         spot: Underlying spot price(s) at expiry. Scalars and array-likes
             are both accepted.
-        strike: Strike price of the option. Must be a non-negative real number.
+        strike: Strike price of the option. Must be a finite, non-negative
+            real number.
 
     Returns:
         Element-wise payoff ``max(strike - spot, 0)`` as a float array.
 
     Raises:
-        ValueError: If ``strike`` is NaN or negative.
+        ValueError: If ``strike`` is not finite (NaN or infinite), or is
+            negative.
     """
     _check_strike(strike)
     return np.maximum(strike - np.asarray(spot, dtype=np.float64), 0.0)

--- a/tests/dummypy/test_payoffs.py
+++ b/tests/dummypy/test_payoffs.py
@@ -90,14 +90,28 @@ def test_put_negative_strike_raises():
 
 def test_call_nan_strike_raises():
     """A NaN strike is rejected with a clear ValueError."""
-    with pytest.raises(ValueError, match="NaN"):
+    with pytest.raises(ValueError, match="finite"):
         call_payoff(100.0, math.nan)
 
 
 def test_put_nan_strike_raises():
     """A NaN strike is rejected with a clear ValueError."""
-    with pytest.raises(ValueError, match="NaN"):
+    with pytest.raises(ValueError, match="finite"):
         put_payoff(100.0, math.nan)
+
+
+@pytest.mark.parametrize("strike", [math.inf, -math.inf])
+def test_call_infinite_strike_raises(strike):
+    """An infinite strike is rejected rather than yielding a degenerate payoff."""
+    with pytest.raises(ValueError, match="finite"):
+        call_payoff(100.0, strike)
+
+
+@pytest.mark.parametrize("strike", [math.inf, -math.inf])
+def test_put_infinite_strike_raises(strike):
+    """An infinite strike is rejected; it used to return an infinite payoff."""
+    with pytest.raises(ValueError, match="finite"):
+        put_payoff(100.0, strike)
 
 
 # --- Property-based invariants -----------------------------------------------


### PR DESCRIPTION
Closes #206.

## The problem

`_check_strike` guarded with `math.isnan(strike)`, which rejects NaN and (via the next
branch) negatives, but let infinity through:

```python
call_payoff(100.0, strike=float("inf"))   # -> 0.0
put_payoff(100.0, strike=float("inf"))    # -> inf
```

Both contradict the documented contract ("Strike price of the option. Must be a
non-negative real number.") and the validator's own stated purpose at
`src/dummypy/payoffs.py:12-14` — fail fast with an actionable message rather than
silently producing a meaningless payoff. An infinite payoff is exactly that.

## The fix

One finiteness branch now covers NaN and `±inf`:

```python
if not math.isfinite(strike):
    msg = f"strike must be a finite real number, got {strike}"
    raise ValueError(msg)
```

The `strike < 0` branch is unchanged, and the ordinary paths are untouched:
`call_payoff(120.0, 100.0)` and `put_payoff(80.0, 100.0)` still return `20.0`.

Also updated:

- docstrings on `_check_strike`, `call_payoff` and `put_payoff` to state the finite
  contract;
- `README.md` — the strike contract now reads "(negative, NaN or infinite)";
- `tests/dummypy/test_payoffs.py` — added `test_call_infinite_strike_raises` and
  `test_put_infinite_strike_raises`, each parametrized over `±inf`.

## One judgement call worth a look

This is committed as `fix:`, not `fix!:`. The reasoning: the docstring already declared
infinite strikes invalid, so this makes the code enforce a contract that was already
published rather than changing a documented one. But it *is* a behaviour change for any
caller who was passing `inf` and reading the result, and the NaN message text changed
too (`"strike must be a real number, got NaN"` → `"strike must be a finite real number,
got nan"`), which would break a caller matching on that string.

If you'd rather that drive a minor bump, changing the commit subject to `fix!:` is the
only edit needed.

## Verification

- `make test` — 54 passed (was 50), coverage **100.00%** on `src/`, the configured bar
- `make fmt` — all 21 hooks Passed
- `make typecheck` — clean under both `ty` and `mypy --strict`
- `make rhiza-test` — 39 passed, 1 skipped; the README code blocks still execute

🤖 Generated with [Claude Code](https://claude.com/claude-code)
