### PR TITLE
docs(readme): drop the hand-maintained footer date that drifted

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,5 +134,6 @@ This software is provided for educational and demonstration purposes. Feel free 
 ---
 
 **Version**: 0.2.0
-**Last Updated**: June 2026
 **Classification**: Public (MIT License)
+
+The release date for each version is in [CHANGELOG.md](CHANGELOG.md).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,12 @@ tag = false
 # The README footer restates the version for readers who never open pyproject.toml.
 # It drifted silently before (0.1.4 -> 0.1.5 was a hand-written fix), so declare it
 # here instead. The `**Version**: ` prefix anchors the match to that one line.
+#
+# The footer also carried a hand-maintained `**Last Updated**` date, which drifted the
+# same way (it still read June 2026 after the August 0.2.0 release). It was removed
+# rather than anchored here: the release date already lives in CHANGELOG.md and in the
+# GitHub release, so a third copy is drift surface without new information. Don't
+# re-add it — point readers at the changelog instead.
 [[tool.bumpversion.files]]
 filename = "README.md"
 search = "**Version**: {current_version}"


### PR DESCRIPTION
Closes #207.

## The problem

The README footer read `**Last Updated**: June 2026`, but 0.2.0 shipped 2026-08-04, and
the README already documented features that landed after June — the `call_payoff` /
`put_payoff` section and the Grid immutability note.

The `**Version**:` line directly above it is kept honest by `[[tool.bumpversion.files]]`
in `pyproject.toml`, which exists because the version had drifted the same way (0.1.4 →
0.1.5 was a hand-written fix). The date line had no such anchor.

## The fix

Removed the line rather than anchoring a second field.

Anchoring was the alternative, and it would work — a `regex = true` entry matching
`\*\*Last Updated\*\*: \w+ \d{4}` with `replace = "**Last Updated**: {now:%B %Y}"`. But
the release date already lives in `CHANGELOG.md` and in the GitHub release, so a third
copy is drift surface without new information, and it needs a regex entry to maintain
where the version line needs a literal one. The footer now points at the changelog
instead, and a comment in `pyproject.toml` records why the line is gone so it doesn't
get re-added.

```diff
 **Version**: 0.2.0
-**Last Updated**: June 2026
 **Classification**: Public (MIT License)
+
+The release date for each version is in [CHANGELOG.md](CHANGELOG.md).
```

## Verification

- `uvx bump-my-version bump patch --dry-run` — the `**Version**:` anchor still resolves
  at `README.md:136` and would bump 0.2.0 → 0.2.1 cleanly; the surviving footer is
  untouched by the edit
- `make fmt` — all 21 hooks Passed, markdownlint included
- `make rhiza-test` — 39 passed, 1 skipped; both the README validation and the
  bumpversion-discoverability tests in `test_pyproject.py` still pass

Docs and config only — no source change, so `make test` is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
