### PR TITLE
chore: drop the redundant SOURCE_FOLDER=src from .rhiza/.env

### DIFF
--- a/.rhiza/.env
+++ b/.rhiza/.env
@@ -9,5 +9,4 @@
 # Variables defined here are exported to all Make recipes.
 
 MARIMO_FOLDER=docs/notebooks
-SOURCE_FOLDER=src
 RHIZA_CI_OS_MATRIX=["ubuntu-latest","macos-latest","windows-latest"]


### PR DESCRIPTION
`SOURCE_FOLDER=src` restated a default in a template-owned file. Deleted.

## Why it is safe

`src` is already `Config.source_folder`'s default in `rhiza-task`, and nothing outside the CLI reads the variable — neither of the two make bridges (`Makefile`'s `-include .rhiza/.env`, `.rhiza/rhiza.mk`'s `ci-os-matrix`) nor any reusable workflow names it. Verified after the change:

- `Config.load()` still resolves `source_folder = src`
- `make -f .rhiza/rhiza.mk -s ci-os-matrix` still emits `["ubuntu-latest","macos-latest","windows-latest"]`

## Why deleted, not moved to `[tool.rhiza-task]`

`pyproject.toml` is the right long-term home for this configuration — it is repo-owned, whereas `.rhiza/.env` is listed in `template.lock`'s `files:` block, and TOML values bypass `rhiza-task`'s string-guessing `_coerce`. But a default declared twice is still declared twice, so the honest change for this one setting is removal.

## Why `MARIMO_FOLDER` stays

It also matches the CLI default, but it is not redundant in the same way: `rhiza_marimo.yml@v1.3.3` reads it out of make's namespace, where the fallback is `marimo`, not `docs/notebooks`. The line is what keeps the two readers agreeing. Whether the path should point at `book/marimo/notebooks` instead is the separate, deliberate change already flagged in `CLAUDE.md`.

## Not in scope

`RHIZA_CI_OS_MATRIX` and `MARIMO_FOLDER` cannot move to `pyproject.toml` while the workflows pin `@v1.3.3` — both are read through make, which cannot parse TOML, and both failures would be silent and green (an ubuntu-only matrix, and a `marimo` notebook folder). That migration is gated on [jebel-quant/rhiza#1546](https://github.com/jebel-quant/rhiza/issues/1546), still open, with `v1.3.3` still the latest tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)