### PR TITLE
chore: migrate to rhiza v1.4.2

### DIFF
--- a/.github/workflows/rhiza_benchmark.yml
+++ b/.github/workflows/rhiza_benchmark.yml
@@ -20,5 +20,5 @@ on:
 
 jobs:
   benchmark:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.3.4
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.4.2
     secrets: inherit

--- a/.github/workflows/rhiza_book.yml
+++ b/.github/workflows/rhiza_book.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   book:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.3.4
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.4.2
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -26,5 +26,5 @@ on:
 
 jobs:
   ci:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.3.4
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.4.2
     secrets: inherit

--- a/.github/workflows/rhiza_codeql.yml
+++ b/.github/workflows/rhiza_codeql.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   codeql:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.3.4
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.4.2
     secrets: inherit
     permissions:
       security-events: write   # Upload CodeQL results to code scanning

--- a/.github/workflows/rhiza_devcontainer.yml
+++ b/.github/workflows/rhiza_devcontainer.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   devcontainer:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_devcontainer.yml@v1.3.4
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_devcontainer.yml@v1.4.2
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_docker.yml
+++ b/.github/workflows/rhiza_docker.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   docker:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_docker.yml@v1.3.4
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_docker.yml@v1.4.2
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_fuzzing.yml
+++ b/.github/workflows/rhiza_fuzzing.yml
@@ -34,7 +34,7 @@ permissions:
 
 jobs:
   fuzzing:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_fuzzing.yml@v1.3.4
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_fuzzing.yml@v1.4.2
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_marimo.yml
+++ b/.github/workflows/rhiza_marimo.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   marimo:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.3.4
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.4.2
     secrets: inherit

--- a/.github/workflows/rhiza_scorecard.yml
+++ b/.github/workflows/rhiza_scorecard.yml
@@ -36,7 +36,7 @@ permissions: read-all
 
 jobs:
   scorecard:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.3.4
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.4.2
     secrets: inherit
     permissions:
       security-events: write   # Upload the SARIF results to code scanning

--- a/.github/workflows/rhiza_weekly.yml
+++ b/.github/workflows/rhiza_weekly.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   weekly:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.3.4
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.4.2
     secrets: inherit

--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -1,13 +1,9 @@
-sha: 0db4dadf0577a3fcaed7881419682f349e5f98c5
+sha: 31e1a11237419f746770c5339f8aa468fd1c0deb
 repo: jebel-quant/rhiza
 host: github
-ref: v1.3.4
+ref: v1.4.2
 include: []
 exclude:
-- .rhiza/tests
-- .rhiza/make.d
-- .rhiza/rhiza.mk
-- Makefile
 - .github/CONFIG.md
 - .github/workflows/rhiza_mutation.yml
 - .github/ISSUE_TEMPLATE
@@ -43,8 +39,6 @@ files:
 - .gitignore
 - .pre-commit-config.yaml
 - .python-version
-- .rhiza/.env
-- .rhiza/.gitignore
 - .rhiza/CODE_OF_CONDUCT.md
 - .rhiza/CONTRIBUTING.md
 - .rhiza/semgrep.yml
@@ -64,5 +58,5 @@ files:
 - pytest.ini
 - ruff.toml
 - tests/test_rhiza_packaging.py
-synced_at: '2026-08-18T15:28:43Z'
+synced_at: '2026-08-19T19:57:52Z'
 strategy: merge

--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -1,5 +1,5 @@
 repository: "jebel-quant/rhiza"
-ref: "v1.3.4"
+ref: "v1.4.2"
 
 profiles:
   - github-project
@@ -9,60 +9,41 @@ templates:
   - github-docker
   - legal
 
-# `.rhiza/tests` is no longer taken from the template. Its seven modules are installed
-# instead, as the `pytest-rhiza` plugin declared in pyproject.toml, and re-exported from
-# `tests/rhiza/` so they run under `make test`. Piloting jebel-quant/rhiza#1540 from the
-# consumer side; drop this entry once the template ships the plugin recipe itself.
+# Four deliberate deletions, excluded rather than simply deleted: a deletion alone is undone
+# by the next sync, which restores the file as untracked. v1.4.2 still ships all four, so
+# every entry here is live -- unlike the six this bump removed (see the end of this file).
+#
+#   .github/CONFIG.md                     97ae7f6 -- PAT_TOKEN docs nothing referenced
+#   .github/workflows/rhiza_mutation.yml  b7d8cf3 -- `make mutation` is broken upstream
+#   .github/ISSUE_TEMPLATE                a606a02
+#   .github/DISCUSSION_TEMPLATE           9917ab3
+#
+# `rhiza_mutation.yml` is excluded *and* deleted, so the gate cannot be re-enabled by
+# flipping a repository variable. That is safe here and was checked, not assumed:
+# `gh variable list` shows no MUTATION_ENABLED, so nothing ever opted this repo in. It also
+# shows FUZZING_ENABLED=true -- which is why `rhiza_fuzzing.yml` is *not* excluded here even
+# though the house set for this migration lists it. This repo configured that gate on
+# purpose, the workflow runs and passes on every PR, and excluding it would both stop the
+# sync bumping its `uses:` pin and delete a workflow in active use.
 exclude:
-  - .rhiza/tests
-
-  # The make layer, replaced by the `rhiza-task` CLI on PyPI: `.rhiza/rhiza.mk` plus ten
-  # fragments under `.rhiza/make.d/`, 1030 lines synced at a template tag, for one pinned
-  # package version in `Makefile`. Recorded as exclusions rather than simply deleted,
-  # because a deletion alone is undone by the next sync.
-  #
-  # `.rhiza/rhiza.mk` outlives the rest by one caller: rhiza_ci.yml@v1.3.3's
-  # `generate-matrix` job runs `make -f .rhiza/rhiza.mk -s ci-os-matrix` in a job that
-  # installs no uv, so twenty repo-owned lines stay at that path. Excluding it is what
-  # stops the sync overwriting them with the 157-line original. @v1.3.4 asks the CLI
-  # instead (jebel-quant/rhiza#1546); the file goes when this repo's workflows pin it.
-  - .rhiza/make.d
-  - .rhiza/rhiza.mk
-
-  # `Makefile` is repo-owned -- CLAUDE.md has said so since the `rhiza-task` migration,
-  # but `.rhiza/template.lock` lists it under `files:` and the lock is what the sync
-  # obeys. The v1.3.4 sync is where that mismatch surfaced: it wrote conflict markers
-  # across the shim, and `/rhiza:update`'s resolver takes the upstream side of every
-  # conflict unconditionally -- which would have replaced Bridge 1, the `book` target and
-  # the `%:` catch-all with the template's `MKDOCS_EXTRA_PACKAGES` make layer.
-  #
-  # Excluding it makes the de facto state explicit: this repo owns the file and stops
-  # receiving template Makefile changes. That is the intent of the migration, which
-  # moved the settings the template's Makefile carried into `[tool.rhiza-task]`.
-  - Makefile
-
-  # Four deliberate deletions the v1.3.4 sync restored, for the reason the make layer is
-  # excluded rather than deleted: a deletion alone is undone by the next sync. Each was
-  # removed on purpose and each came back as an untracked file.
-  #
-  #   .github/CONFIG.md                     97ae7f6 -- PAT_TOKEN docs nothing referenced
-  #   .github/workflows/rhiza_mutation.yml  b7d8cf3 -- `make mutation` is broken upstream
-  #   .github/ISSUE_TEMPLATE                a606a02
-  #   .github/DISCUSSION_TEMPLATE           9917ab3
   - .github/CONFIG.md
   - .github/workflows/rhiza_mutation.yml
   - .github/ISSUE_TEMPLATE
   - .github/DISCUSSION_TEMPLATE
 
-  # The dotenv layer, deleted now that `[tool.rhiza-task]` in pyproject.toml is the only
-  # place this repo configures the task layer. Same rule again, and it very nearly caught
-  # this change out: both paths were still under `files:` in the lock the v1.3.4 sync
-  # regenerated, so without these two lines the next `/rhiza:update` would have written
-  # `.rhiza/.env` back -- and `rhiza-task` reads it at layer 2, *below* pyproject.toml, so
-  # a restored file would not even have overridden the matrix. It would just have sat
-  # there as a second, silent home for settings that now live in one place.
-  #
-  # `.rhiza/.gitignore` held exactly one rule, `!.env`, which un-ignored `.rhiza/.env`
-  # against `.gitignore`'s `.env`. It has nothing left to un-ignore.
-  - .rhiza/.env
-  - .rhiza/.gitignore
+# Six entries went with the v1.4.2 bump, all of them dead rather than resolved -- v1.4.2
+# ships none of these paths, so there is nothing left for an exclusion to intercept. Checked
+# against a v1.4.2 lock (jebel-quant/linalg), not assumed:
+#
+#   Makefile, .rhiza/rhiza.mk, .rhiza/make.d  -- the make layer, which v1.4.0 stopped
+#       shipping. The `rhiza-task` CLI replaced it; the settings those files carried live in
+#       `[tool.rhiza-task]` in pyproject.toml. The root `Makefile` survives as a repo-owned
+#       shim over the CLI, and no longer needs excluding to stay that way: a sync that
+#       delivers no Makefile cannot overwrite one.
+#   .rhiza/.env, .rhiza/.gitignore           -- the dotenv layer, gone for the same reason.
+#       The v1.3.4 lock still listed both under `files:`, which is what made the exclusion
+#       load-bearing then; v1.4.2 does not list them at all.
+#   .rhiza/tests                             -- the in-tree conformance checks. This repo
+#       took the `pytest-rhiza` distribution instead (jebel-quant/rhiza#1540, piloted from
+#       the consumer side and re-exported by `tests/rhiza/`); v1.4.2 no longer ships the
+#       folder, so the pilot's exclusion has nothing to suppress.

--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -38,8 +38,13 @@ exclude:
 #   Makefile, .rhiza/rhiza.mk, .rhiza/make.d  -- the make layer, which v1.4.0 stopped
 #       shipping. The `rhiza-task` CLI replaced it; the settings those files carried live in
 #       `[tool.rhiza-task]` in pyproject.toml. The root `Makefile` survives as a repo-owned
-#       shim over the CLI, and no longer needs excluding to stay that way: a sync that
-#       delivers no Makefile cannot overwrite one.
+#       shim over the CLI, restored byte-identical after this very sync deleted it -- which
+#       is the detail worth recording: dropping the exclusion did not merely stop the file
+#       being *delivered*, it let the v1.3.4 -> v1.4.2 delete pass remove a repo-owned file,
+#       because that pass acts on what the old ref shipped and does not consult `exclude:`.
+#       No exclusion is needed to keep it from here: the deletion was a one-off transition
+#       artefact, and a later sync between two refs that both ship no Makefile has nothing
+#       to delete.
 #   .rhiza/.env, .rhiza/.gitignore           -- the dotenv layer, gone for the same reason.
 #       The v1.3.4 lock still listed both under `files:`, which is what made the exclusion
 #       load-bearing then; v1.4.2 does not list them at all.

--- a/docs/development/VSCODE_EXTENSIONS.md
+++ b/docs/development/VSCODE_EXTENSIONS.md
@@ -188,7 +188,7 @@ in the Rhiza repository for the exact list.
 ## Related Documentation
 
 - [DevContainer Configuration](DEVCONTAINER.md) - Dev container setup and usage
-- [Makefile Customisation](../../.rhiza/make.d/README.md) - Task automation and customization
+- [Makefile Customisation](../../README.md#makefile-customisation) - Task automation and customization
 - [Marimo Documentation](MARIMO.md) - Interactive notebooks and Marimo integration
 - [Quick Reference](../guides/QUICK_REFERENCE.md) - Common development tasks
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,40 +111,71 @@ plotly = "plotly"
 
 # The developer tasks come from `rhiza-task` on PyPI (see Makefile and CLAUDE.md); this
 # table is where what used to be a make variable, or a target shadowed in the root
-# Makefile, is said instead.
+# Makefile, is said instead. It is read as layer 3 of the CLI's resolution order
+# (defaults -> .rhiza/.env -> pyproject.toml -> RHIZA_* environment); layer 2 is gone,
+# so this is the only place the repo configures the task layer.
+#
+# Only entries that differ from the CLI's own default belong here -- `uvx rhiza-task print
+# <setting>` shows what one resolves to. Every value below was re-checked against
+# rhiza-task@0.3.1, which is the version `rhiza_ci.yml@v1.4.2` pins for every gate step;
+# the `RHIZA_TASK` pin in the Makefile governs local `make` only.
 [tool.rhiza-task]
 # The OS matrix CI runs on, moved here from `.rhiza/.env` now that nothing reads that file.
 #
 # Not optional, and not a default restated: `rhiza-task`'s own default is `["ubuntu-latest"]`.
-# rhiza_ci.yml@v1.3.4's `generate-matrix` exports RHIZA_CI_OS_MATRIX as the empty string for
-# every repository that is not the mother -- deliberately, so the consumer answers -- and the
-# CLI treats an empty setting as unset. With the dotenv deleted and nothing said here, the
-# answer would be the default: CI would keep passing while quietly testing one OS instead of
-# three. That is the failure mode worth spelling out, because it is green.
+# rhiza_ci.yml's `generate-matrix` asks the CLI (`uvx rhiza-task@0.3.1 ci-os-matrix`) and
+# exports RHIZA_CI_OS_MATRIX as the empty string for every repository that is not the mother
+# -- deliberately, so the consumer answers -- and the CLI treats an empty setting as unset.
+# With the dotenv deleted and nothing said here, the answer would be the default: CI would
+# keep passing while quietly testing one OS instead of three. That is the failure mode worth
+# spelling out, because it is green.
 ci-os-matrix = ["ubuntu-latest", "macos-latest", "windows-latest"]
 
 # python.mk's default was `both`; rhiza-task's is `ty`. Said here so the migration does not
 # quietly stop running mypy --strict -- which this project is written for, down to the
-# [[tool.mypy.overrides]] entry for pandas above.
+# [[tool.mypy.overrides]] entry for pandas above. It is also stricter than the make layer
+# was: the retired shell `case` let mypy's exit status win, so a `ty` failure could pass,
+# where the CLI raises on each run.
 typechecker = "both"
 
 # src/ is fully covered and stays that way. This was `COVERAGE_FAIL_UNDER = 100` in the
 # root Makefile, deliberately there rather than in the uncommitted local.mk so that a
-# regression below 100% fails `make test` for everyone. It still does.
+# regression below 100% fails `make test` for everyone. It still does. The CLI default is
+# 90, and `test` passes --cov-fail-under on the command line, which outranks
+# [tool.coverage.report] -- so this line, not that table, is the gate.
 coverage_fail_under = 100
 
-# docs/api is generated from the docstrings, and zensical does not ship mkdocstrings. Was
-# `MKDOCS_EXTRA_PACKAGES = --with 'mkdocstrings[python]'`; the flag is the CLI's business
-# now, so only the package name is given.
-mkdocs-extra-packages = ["mkdocstrings[python]"]
-
 # pytest-rhiza from PyPI, pinned exactly rather than floored: a gate that moves under you
-# is not a gate. rhiza-task 0.1.2's own default still names the git tag, one patch behind.
-# The `test` dependency group pins the same distribution for a different reason -- there it
-# is what `tests/rhiza/` imports under `make test`; here it is what `make rhiza-test`
-# provisions on the fly. Keep the two in step.
+# is not a gate. The CLI's default still names a git tag at v0.2.0, one patch behind, so
+# dropping this line would *downgrade* the conformance checks. The `test` dependency group
+# pins the same distribution for a different reason -- there it is what `tests/rhiza/`
+# imports under `make test`; here it is what `make rhiza-test` provisions on the fly.
+# Keep the two in step.
 pytest-rhiza = "pytest-rhiza==0.2.1"
 
+# Not set, on purpose. Each of these was checked against rhiza-task@0.3.1 rather than
+# recalled, and this note is here to stop them being re-added:
+#
+#   mkdocs-extra-packages -- was `["mkdocstrings[python]"]` here until the v1.4.2 bump, and
+#                          that is now the CLI's default verbatim, so the entry restated it.
+#                          Naming the setting *replaces* the default list rather than adding
+#                          to it, which makes a redundant entry a liability: it is the line
+#                          someone edits to add a package and accidentally drops
+#                          mkdocstrings from the book build with. docs/api/*.md still needs
+#                          mkdocstrings for its `:::` directives -- it just gets it by
+#                          default now. Verified behaviour-neutral: `print
+#                          mkdocs_extra_packages` returns `mkdocstrings[python]` either way.
+#   marimo-folder        -- the notebooks are in `book/marimo/notebooks/` and the CLI
+#                          defaults to `docs/notebooks`, so this one is a *known* mismatch
+#                          left alone rather than a default agreed with. Setting it would
+#                          newly run those notebooks in CI -- a change of behaviour, not of
+#                          configuration. See the "Known broken" section of CLAUDE.md.
+#   source-folder, layers -- already the defaults (`src`, `python`).
+#   license-ignore-packages -- default empty, and correct: nothing here wraps or vendors a
+#                          GPL distribution, so the `license` gate's
+#                          `--fail-on=GPL;LGPL;AGPL` has nothing to forgive. Do not add
+#                          `docutils`; rhiza-task appends that itself when marimo is in the
+#                          task registry.
 # tests/rhiza/ mirrors no module under src/ and never will — the checks assert about
 # the repository, not about dummypy — so the 1:1 layout checker would read the files as
 # orphan tests. Exempting the one directory keeps parity enforced everywhere else,


### PR DESCRIPTION
## What

Bumps the rhiza template from **v1.3.4 → v1.4.2** and re-verifies the settings the retired
make layer used to carry.

This repo is an unusual case for this migration. It retired the make layer ahead of the
fleet — `Makefile` became a repo-owned shim over `rhiza-task`, `.rhiza/rhiza.mk`,
`.rhiza/make.d/`, `.rhiza/.env` and `.rhiza/.gitignore` were already deleted, and
`[tool.rhiza-task]` already existed. So the regression this migration normally exists to
prevent (a green PR that silently relaxes every gate) was not on the table here. What was
still outstanding is the version bump, an exclude list that v1.4.0 had made largely dead,
and an audit of the settings against the version v1.4.2 actually runs.

**No gates were run.**

## Settings

Re-checked with `uvx rhiza-task@0.3.1 print <setting>` rather than recalled — the reusable
`rhiza_ci.yml@v1.4.2` pins `rhiza-task@0.3.1` for every gate step ("pinned here rather than
read from a consumer's `RHIZA_TASK`"), and the CLI's defaults have moved between releases.
All four survivors are still non-defaults and resolve unchanged:

| setting | CLI default (0.3.1) | now | what a missing line costs |
|---|---|---|---|
| `ci-os-matrix` | `["ubuntu-latest"]` | three OSes | CI stays green while testing 1 OS instead of 3 |
| `typechecker` | `ty` | `both` | `mypy --strict` silently stops running |
| `coverage_fail_under` | `90` | `100` | the 100% gate relaxes to 90 (CLI passes `--cov-fail-under`, which outranks `[tool.coverage.report]`) |
| `pytest-rhiza` | `git+…pytest-rhiza@v0.2.0` | `==0.2.1` | conformance checks *downgrade* a patch |

One entry removed: **`mkdocs-extra-packages`**. `["mkdocstrings[python]"]` is now the CLI's
default verbatim, so the line restated it. Verified behaviour-neutral — `print
mkdocs_extra_packages` returns `mkdocstrings[python]` before and after. Worth removing rather
than leaving, because naming the setting *replaces* the default list, which makes a redundant
entry the line someone edits to add a package and silently drops mkdocstrings from the book
build with. `docs/api/*.md` still needs it for its `:::` directives; it just gets it by default.

`marimo-folder`, `source-folder`, `layers` and `license-ignore-packages` are recorded in a
"not set, on purpose" block, so the next reader can tell a default agreed with from a
mismatch left alone deliberately (`marimo-folder` is the latter — see *Known drift*).

## Sync

`sync.py` exited **0** — no conflicts, so `resolve_conflicts.py` never ran and **no hunk was
taken from upstream over a local edit**. 11 files merged, 15 upstream paths no longer shipped.

Ten of the eleven are consumer callers, each a single-line `uses: …@v1.3.4` → `@v1.4.2` pin
bump. The eleventh is `docs/development/VSCODE_EXTENSIONS.md`, where the template repointed a
link off `.rhiza/make.d/README.md`.

### The Makefile was deleted, and restored

The sync deleted the root `Makefile` even though it was listed under `exclude:`. Worth
stating plainly, because it is not what the exclusion implies: the delete pass acts on the
paths the **old** ref shipped and does not consult `exclude:`, so an excluded, repo-owned file
was removed. `stage_synced.py` correctly left it unstaged as not template-owned.

It was restored **byte-identical from `main`** rather than regenerated with `uvx rhiza-task
shim` — the repo's shim carries three things a fresh shim does not: the uv bootstrap bridge,
an explicit `.PHONY: book` rule (the `book/` directory would otherwise shadow the task), and
the `local.mk: ;` / `Makefile: ;` lines. **This PR therefore contains no change to
`Makefile`**, and `make -n test` / `make -n book` still forward correctly.

No exclusion was reinstated: the deletion is a one-off artefact of this transition, since a
later sync between two refs that both ship no Makefile has nothing to delete.

## Excludes

Six of the ten entries were **dead, not resolved** — v1.4.2 ships none of these paths, so
there is nothing left to intercept. Checked against a real v1.4.2 lock
(`jebel-quant/linalg`), not assumed:

- `Makefile`, `.rhiza/rhiza.mk`, `.rhiza/make.d` — the make layer, unshipped since v1.4.0
- `.rhiza/.env`, `.rhiza/.gitignore` — the dotenv layer. The v1.3.4 lock still listed both
  under `files:`, which is what made the exclusion load-bearing then; v1.4.2 does not list
  them at all, so the second silent home for settings cannot return
- `.rhiza/tests` — the in-tree conformance checks, replaced here by the `pytest-rhiza`
  distribution (jebel-quant/rhiza#1540, piloted consumer-side and re-exported by `tests/rhiza/`)

The four that remain are live — v1.4.2 still ships all of them, and each was deleted here on
purpose: `.github/CONFIG.md`, `.github/workflows/rhiza_mutation.yml`, `.github/ISSUE_TEMPLATE`,
`.github/DISCUSSION_TEMPLATE`. None was restored by the sync, so there was nothing to `git rm`.

No entry needed rewriting from clone-relative to destination form — this repo's were already
destination-spelled and working.

### `rhiza_fuzzing.yml` deliberately *not* excluded

The house set for this migration lists it, and it is wrong for this repo. `gh variable list`
shows **`FUZZING_ENABLED=true`** — this repo opted into that gate on purpose, and `(RHIZA)
FUZZING` runs and passes on every PR. Excluding it would have stopped the sync bumping its
`uses:` pin *and* deleted a workflow in active use, unrecoverable by flipping the variable
back. `MUTATION_ENABLED` is absent, which is why the mutation caller stays excluded and deleted.

## Known drift — flagged, not fixed here

1. **The Makefile's uv bridge is now obsolete.** Its comment says "delete this block when the
   reusable workflows install uv for that job" — and `rhiza_ci.yml@v1.4.2`'s `pre-commit` job
   now *has* a `setup-uv` step. The condition is met, but removing it is a repo-owned change
   outside this PR's remit, and the block is harmless (it only fires when `uvx` is absent).
2. **`RHIZA_TASK ?= rhiza-task@0.1.2` in the Makefile is three minor versions behind the
   `0.3.1` CI runs.** It governs local `make` only, so this is a local/CI divergence rather
   than a gate weakness — but it means a human's `make test` and CI are not the same code, and
   `0.1.2` is the version with the `uv_sync_args` splat bug that breaks the devcontainer
   bootstrap (CLAUDE.md, *Known broken*). Worth its own PR.
3. **`docs/development/VSCODE_EXTENSIONS.md`'s link is broken here** — the template repointed
   it at `README.md#makefile-customisation`, and this README has no such heading. Broken before
   the bump too (the old target, `.rhiza/make.d/README.md`, was already deleted), so no
   regression; the fix is a repo-owned README change.
4. **`CLAUDE.md` still describes the v1.3.4 world** in places — `rhiza_ci.yml@v1.3.4`, the uv
   bridge as live, and `.rhiza/rhiza.mk`'s exclusion. Repo-owned docs, so a separate PR.
5. **`marimo-folder` remains unset**, so the notebooks in `book/marimo/notebooks/` are still
   not exercised. Setting it would newly run them in CI — a change of behaviour, to be done
   deliberately.
6. **Sibling repos carry dead excludes.** `linalg`, and by inspection the other already-migrated
   repos, spell theirs clone-relative (`bundles/github/.github/workflows/rhiza_fuzzing.yml`),
   which matches nothing — `rhiza_fuzzing.yml` is in `linalg`'s lock and being delivered
   despite the entry. Not this repo's problem, but it is a fleet-wide one.

Nothing was left unstaged.
