### PR TITLE
docs(packaging): state one public/private intent in both places

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,6 @@ This software is provided for educational and demonstration purposes. Feel free 
 ---
 
 **Version**: 0.2.0
-**Classification**: Public (MIT License)
+**Classification**: Public source, MIT licensed — not distributed on PyPI (`Private :: Do Not Upload` in `pyproject.toml`)
 
 The release date for each version is in [CHANGELOG.md](CHANGELOG.md).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,8 @@ license = "MIT"
 readme = "README.md"
 requires-python = ">=3.11"
 keywords = ["dummypy", "analytics", "demo", "example"]
+# The release workflow greps this list for "Private :: Do Not Upload" to decide
+# whether to publish; removing that classifier starts uploading to PyPI.
 classifiers = [
     "Private :: Do Not Upload",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
Closes #188.

The issue has two halves; only one was outstanding.

**Python classifiers — already in place.** `pyproject.toml` lists 3.11 through 3.14, consistent with `requires-python = ">=3.11"` and `.python-version` = 3.12.

**Public vs Private — fixed on the README side.** The issue suggests "drop one or align the wording". Dropping `Private :: Do Not Upload` is not safe: `rhiza_release.yml`'s `pypi` job greps `pyproject.toml` for that literal string to set `should_publish`, so removing it would start uploading `dummypy` to PyPI under Trusted Publishing on the next tag. That workflow is rhiza-synced, so the grep cannot be changed here either.

So the classifier is a functional switch, and the README's "Public (MIT License)" was the inaccurate half. It now reads *Public source, MIT licensed — not distributed on PyPI*, and the classifier list carries a comment recording the grep so the contradiction is not resolved from the publishing side later.

Docs and metadata only; no code or dependency change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)