### PR TITLE
docs(claude): drop the non-existent `make validate` gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,8 +8,16 @@ This repo syncs its development infrastructure from the
 [`jebel-quant/rhiza`](https://github.com/jebel-quant/rhiza) template. Some files
 are **owned upstream** (regenerated on every sync — edit them in Rhiza, not
 here) and some are **locally owned** (this repo controls them). Editing a
-synced file locally will be reverted by the next `rhiza` sync and will fail the
-`make validate` / template-fidelity checks.
+synced file locally will be reverted by the next `rhiza` sync, which rewrites the
+file from the template.
+
+No local gate catches such an edit before then. There is no `validate` target —
+`make` forwards to `rhiza-task`, whose task list has none, so `make validate`
+dies with an unknown-task error — and `.rhiza/template.lock` records a template
+`sha` for the payload as a whole, not per-file hashes anything could check
+against. `/rhiza:status --check` is what reports the drift; pre-commit's
+`check-rhiza-config` hook (run by `make fmt`) validates `.rhiza/template.yml`
+itself, not the synced files it selects.
 
 ### Rhiza-synced — fix upstream, don't edit here
 


### PR DESCRIPTION
Closes #189.

Two items in the issue; one is real, one was already settled the other way.

## `make validate` — fixed

The ownership section told contributors that editing a synced file "will fail the `make validate` / template-fidelity checks". Nothing of the sort exists:

- `Makefile` forwards every target to `rhiza-task`, and `rhiza-task list` has no `validate` task at **0.1.2** (what `RHIZA_TASK` pins for local `make`) or **0.3.1** (what the workflows pin). `make validate` lands on the catch-all and dies with an unknown-task error.
- `.rhiza/template.lock` records a single template `sha` for the payload, not per-file hashes, so nothing local can compare a synced file against upstream.

The section now says what actually happens: the next sync rewrites the file, nothing catches the edit before then, `/rhiza:status --check` reports the drift, and pre-commit's `check-rhiza-config` validates `.rhiza/template.yml` itself rather than the files it selects.

Every other `make` target named in `CLAUDE.md` and `README.md` was checked against `rhiza-task list` — `book`, `fmt`, `install`, `test`, `test-pyproject`, `rhiza-test`, `marimo-validate`, `mutation`, `clean`, `help` all exist. (`make view-prs` appears only as something that was retired.)

## README footer — no change, deliberately

The issue asks to remove the hardcoded `**Version**` line and drop or correct `Last Updated`. Both were already handled at the 0.2.0 release, in the other valid direction — see `pyproject.toml:84-96`:

- `**Last Updated**` was **removed**, with a comment saying not to re-add it.
- `**Version**` is no longer hand-maintained: it is a `[[tool.bumpversion.files]]` anchor, so `bump-my-version` rewrites it from `[project].version` on release. One source of truth, one writer.

Deleting the line now would break the release flow — `bump-my-version`'s configured `search` string would no longer match — so it stays. The issue's "0.1.5 / June 2026" quote is itself stale; the footer reads 0.2.0 and carries no date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)