### PR TITLE
docs(claude): record why radon's MI fell 24 points

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,24 @@ nothing observable, for the reason given under *Known broken* below.
 - Bump the task layer by editing `RHIZA_TASK` in the `Makefile` — that is the
   whole version contract.
 
+## Measurement caveats
+
+- **radon's maintainability index drops when you document the code.** Nothing
+  here runs radon — it is not a gate, a hook or a workflow — but a quality
+  review that reaches for it will find `grid.py` at MI 34.44 and `payoffs.py`
+  at 31.78, down about 24 points from 58.56 and 61.25 before the #231 merge
+  (`f61d135` → `c5f1d8f`). Not one executable line changed across that merge:
+  `LLOC` stayed 36 and 20, `SLOC` 27 and 16, average cyclomatic complexity
+  1.875 (A) over the same 8 blocks with none ranking worse than A. Only
+  `Multi` — docstring lines — grew, 53 → 90 and 36 → 75, when #231 added 19
+  doctests. radon's MI takes docstrings as length but credits only `#` lines
+  in its comment term, so documentation is pure penalty; with 59% of their
+  lines docstring or comment, both modules sit near the worst case for that
+  formula. Both are still rank A (threshold 20), ~12 points of headroom. Track
+  `LLOC` or CC for a trend line, and do not delete docstrings to move this
+  number.
+  ([#234](https://github.com/markrichardson/dummyrepo/issues/234))
+
 ## Known broken, and not this repo's doing
 
 - **`make mutation`** fails, and did before the task migration: both the retired


### PR DESCRIPTION
Closes #234.

The issue is informational — "nothing to change in `src/`", close once the explanation lives somewhere a future reader will find it. This puts it in `CLAUDE.md`, under a new **Measurement caveats** section next to the other caveats, which is the option the issue offers.

I reproduced every figure before writing it down, checking out `f61d135`'s `src/dummypy` into a scratch tree and running radon there against the current tree:

| | MI before → after | LLOC | SLOC | `Multi` |
| --- | --- | --- | --- | --- |
| `grid.py` | 58.56 → 34.44 | 36 → 36 | 27 → 27 | 53 → 90 |
| `payoffs.py` | 61.25 → 31.78 | 20 → 20 | 16 → 16 | 36 → 75 |

Average CC is 1.875 (A) over 8 blocks at both commits, nothing ranking worse than A. All six of the issue's numbers match exactly, so the diagnosis holds: only docstring volume moved, and radon's MI charges docstrings as length while crediting only `#` lines in its comment term.

One thing the note adds that the issue does not: **nothing in this repo runs radon.** `grep -ri radon` over the tree, excluding `.git`, returns nothing — it is not a gate, a hook, a workflow or a dependency. So there is no trend line to fix and no threshold at risk; the number only appears when someone runs the tool by hand during a review, which is exactly the reader the note is aimed at.

Docs only — no change under `src/`, and no gate touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)