### PR TITLE
docs: correct the exclude: claims in CLAUDE.md and template.lock

### DIFF
--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -6,6 +6,7 @@ include: []
 exclude:
 - .github/CONFIG.md
 - .github/workflows/rhiza_mutation.yml
+- .github/workflows/rhiza_fuzzing.yml
 - .github/ISSUE_TEMPLATE
 - .github/DISCUSSION_TEMPLATE
 templates:
@@ -31,7 +32,6 @@ files:
 - .github/workflows/rhiza_codeql.yml
 - .github/workflows/rhiza_devcontainer.yml
 - .github/workflows/rhiza_docker.yml
-- .github/workflows/rhiza_fuzzing.yml
 - .github/workflows/rhiza_marimo.yml
 - .github/workflows/rhiza_release.yml
 - .github/workflows/rhiza_scorecard.yml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,10 +44,12 @@ across the shim.
 - `tests/` — the local test suite (mirrors `src/` 1:1), plus `tests/rhiza/`
   (see below)
 - `pyproject.toml` — project metadata, dependencies, and `[tool.rhiza-task]`
-- `Makefile` — a shim forwarding to `rhiza-task` (see below). Repo-owned in
-  `.rhiza/template.yml`'s `exclude:` as well as here: the lock listed it under
-  `files:` until the v1.3.4 sync tried to overwrite the shim with the template's
-  make layer, and the lock is what the sync obeys.
+- `Makefile` — a shim forwarding to `rhiza-task` (see below). Repo-owned in the
+  strong sense at v1.4.2: core ships no `Makefile`, and it does not appear in
+  `.rhiza/template.lock`'s `files:` block, so nothing upstream regenerates it.
+  It has no `exclude:` entry, and one would not protect it: the v1.3.4 → v1.4.2
+  sync deleted it regardless, because the delete pass acts on what the *old* ref
+  shipped and does not consult `exclude:`. It was restored byte-identical.
 - `README.md` — project documentation
 - `CHANGELOG.md` — public API surface across releases
 - `CLAUDE.md` — this file
@@ -61,8 +63,10 @@ CI invokes. But `Makefile` no longer *contains* them: it is a catch-all that
 forwards every target to
 [`rhiza-task`](https://github.com/jebel-quant/rhiza-task) on PyPI, pinned by the
 one `RHIZA_TASK` variable at the top. That replaced `.rhiza/rhiza.mk` plus ten
-fragments under `.rhiza/make.d/` — 1030 synced lines, at a template tag, all of
-them excluded in `.rhiza/template.yml` now.
+fragments under `.rhiza/make.d/` — 1030 synced lines, at a template tag. None of
+them needs an `exclude:` entry now, and none has one: v1.4.0 retired that layer
+upstream, so core delivers no make layer at all, and nothing under
+`.rhiza/make.d/` appears in the lock's `files:` block.
 
 Consequences worth knowing:
 
@@ -117,11 +121,11 @@ nothing observable, for the reason given under *Known broken* below.
   and each source `class A` has a matching `TestA` (enforced by the
   test-layout checker).
 - Coverage gate is 100% on `src/`.
-- The rhiza conformance checks are **not** synced into `.rhiza/tests/`. That
-  folder is listed under `exclude:` in `.rhiza/template.yml`; the checks come
-  from the `pytest-rhiza` distribution declared in `pyproject.toml` and are
-  re-exported by `tests/rhiza/` so `make test` collects them. That re-export is
-  what puts them in CI: the reusable workflow runs `make test`, never
+- The rhiza conformance checks are **not** synced into `.rhiza/tests/`. v1.4.2
+  core ships no such folder, so it needs no `exclude:` entry and has none; the
+  checks come from the `pytest-rhiza` distribution declared in `pyproject.toml`
+  and are re-exported by `tests/rhiza/` so `make test` collects them. That
+  re-export is what puts them in CI: the reusable workflow runs `make test`, never
   `make rhiza-test`. Consumer-side pilot of
   [jebel-quant/rhiza#1540](https://github.com/jebel-quant/rhiza/issues/1540).
 - Bump the template with the `/rhiza:update` flow; don't hand-edit synced files.


### PR DESCRIPTION
Fixes two bookkeeping inconsistencies found by `/rhiza:quality`. Documentation
and one config file only — no source, no test, no workflow changes.

## `chore(rhiza)`: reconcile `template.lock`'s `exclude:` with `template.yml` — closes #247

`b37e9e4` added `.github/workflows/rhiza_fuzzing.yml` to `.rhiza/template.yml`'s
`exclude:` and `2d9b2f0` deleted the workflow, but neither updated
`.rhiza/template.lock`. The lock still listed the file under `files:` — claiming
it was managed and delivered, when it is absent from disk — and omitted it from
its own `exclude:`.

The entry moves to `exclude:`, in the position `template.yml` uses, so the two
blocks now compare equal including order:

```
lock exclude == yml exclude : True
fuzzing in files:           : False
files count                 : 42   (was 43)
```

`sha`, `ref` and `synced_at` are untouched — they still record the real
2026-08-19 sync at v1.4.2.

**On hand-editing a generated file.** `/rhiza:update` is the sanctioned route,
but it syncs to the *latest* template release: a version bump with its own blast
radius, to fix two lines of bookkeeping. The next sync rewrites this file
wholesale, so this reconciles the current state rather than establishing a
durable contract. Worth watching: if the lock's generator derives `files:` from
the template payload without subtracting `exclude:`, the inconsistency will
return on the next sync — that would be an upstream bug, and this commit masks
the evidence for it.

## `docs(claude)`: correct three claims about `template.yml`'s `exclude:` — closes #246

CLAUDE.md asserted that `Makefile`, `.rhiza/tests/`, `.rhiza/rhiza.mk` and the
ten `.rhiza/make.d/` fragments are listed under `exclude:` in
`.rhiza/template.yml`. None of them is — that block has five entries and all are
under `.github/`.

#246 named two of these; the third (`rhiza.mk` / `make.d`) turned up while
checking the rest of the file, and it contradicted the accurate statement further
down that "the file and its `exclude:` entry both went".

Every one of those files is safe from the sync anyway, but for a different
reason: v1.4.x core ships none of them, and none appears in
`.rhiza/template.lock`'s `files:` block. The text now states that mechanism,
since the lock is what the sync obeys — as CLAUDE.md already says two sections
up.

The `Makefile` entry additionally records that an `exclude:` entry would *not*
have protected it: the delete pass acts on what the old ref shipped and does not
consult `exclude:`, which is why the v1.3.4 → v1.4.2 sync deleted it regardless
and it had to be restored byte-identical. That is the part a future contributor
is most likely to get wrong.

## Verification

- `make fmt` — 20 hooks pass (markdownlint, `check-rhiza-config`, `check yaml`)
- `make rhiza-test` — 34 conformance checks pass
- pre-commit ran on both commits
- `exclude:` blocks compared equal by parsing both files with `yaml.safe_load`
- every remaining `exclude:` reference in CLAUDE.md re-read and confirmed against
  the actual file

## Not addressed here

`CLAUDE.md:61-62` says `make test`, `make fmt` and `make book` "are still what CI
invokes". They are not — the workflows delegate to
`jebel-quant/rhiza/...@v1.4.2`, which pins its own CLI, and the `Makefile` header
states that "Nothing in CI depends on this file any more". `make book` also does
not currently work at all (#244). Out of scope for #246, but it is the sentence
most likely to mislead someone debugging a CI-versus-local discrepancy — which is
exactly the trap #244 describes. Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
