### PR TITLE
fix: close the three remaining /rhiza:quality findings (#244, #245, #248)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,22 +90,37 @@ help: $(UVX_BOOTSTRAP)
 	@$(UVX) $(RHIZA_TASK) list
 
 # The generated shim warns that "a *file* sharing a task's name would shadow it -- none
-# do". In this repository one does: `book/` holds the marimo notebooks and the minibook
-# templates. make finds the directory, calls the target up to date and prints
-# "make: `book' is up to date" instead of building anything.
+# do". In this repository two do, for different reasons, and both need the same treatment.
 #
-# That used to break CI silently: rhiza_book.yml and rhiza_mutation.yml both ran
+# `book/` holds the marimo notebooks and the minibook templates. make finds the directory,
+# calls the target up to date and prints "make: `book' is up to date" instead of building
+# anything. That used to break CI silently: rhiza_book.yml and rhiza_mutation.yml both ran
 # `make book`. Neither does now -- @v1.4.2's book workflow calls `uvx rhiza-task book`, and
 # rhiza_mutation.yml is excluded *and* deleted in this repo (see .rhiza/template.yml). What
 # the rule still buys is the human case: `make book` producing silence instead of a book.
 #
-# Both lines are needed, and neither alone is enough. `.PHONY` stops make consulting the
-# filesystem -- but it also makes make *skip the implicit-rule search*, so the catch-all
-# below stops matching and `book` becomes "nothing to be done". The explicit rule supplies
-# what the catch-all no longer can. This is what the retired book.mk did, minus the recipe.
-.PHONY: book
+# `LICENSE` is the subtler one, because the names do not actually match: the task is
+# `license` and the file is `LICENSE`. On a case-insensitive filesystem -- macOS APFS/HFS+
+# and Windows, two of the three in `ci-os-matrix` -- make's stat for `license` finds
+# `LICENSE` anyway and reports "make: `license' is up to date", so the copyleft scan never
+# runs. Ubuntu is case-sensitive and unaffected, which is exactly what made this invisible:
+# a gate reporting success while measuring nothing, in the one place CI cannot see it.
+# Found by /rhiza:quality; see #245.
+#
+# Both lines are needed in each case, and neither alone is enough. `.PHONY` stops make
+# consulting the filesystem -- but it also makes make *skip the implicit-rule search*, so
+# the catch-all below stops matching and the target becomes "nothing to be done". The
+# explicit rule supplies what the catch-all no longer can. This is what the retired book.mk
+# did, minus the recipe.
+#
+# Any future task whose name collides with a root path -- case-insensitively -- needs an
+# entry here too. `ls | tr A-Z a-z` against `uvx rhiza-task list` is how to check.
+.PHONY: book license
 book: $(UVX_BOOTSTRAP)
 	@$(UVX) $(RHIZA_TASK) book
+
+license: $(UVX_BOOTSTRAP)
+	@$(UVX) $(RHIZA_TASK) license
 
 # `%:` matches any target make cannot otherwise resolve. Two caveats, both survivable: a
 # typo is routed here too (the CLI's "unknown task" error is the backstop), and a task

--- a/README.md
+++ b/README.md
@@ -83,12 +83,18 @@ new `Grid` instead of mutating one.
 ```python
 from dummypy import Grid
 
-grid = Grid(n=3)           # (n + 1) x (n + 1) coordinate frames
-grid.x.shape               # -> (4, 4)
-grid.diff().loc["2", "1"]  # -> np.int64(1)   (x - y at those coordinates)
+grid = Grid(n=3)  # (n + 1) x (n + 1) coordinate frames
+
+print(grid.x.shape)
+print(repr(grid.diff().loc["2", "1"]))  # x - y at those coordinates
 
 # Grid(n=-1) raises ValueError: Grid size n must be non-negative
 # grid.n = 5 raises attr.exceptions.FrozenInstanceError - build a new Grid instead
+```
+
+```result
+(4, 4)
+np.int64(1)
 ```
 
 ### `call_payoff` / `put_payoff`
@@ -101,13 +107,22 @@ invalid `strike` (negative, NaN or infinite) raises a `ValueError`.
 ```python
 from dummypy import call_payoff, put_payoff
 
-call_payoff(120.0, strike=100.0)                  # -> np.float64(20.0)
-put_payoff(80.0, strike=100.0)                    # -> np.float64(20.0)
+# A scalar spot yields a np.float64 ...
+print(repr(call_payoff(120.0, strike=100.0)))
+print(repr(put_payoff(80.0, strike=100.0)))
 
-call_payoff([80.0, 100.0, 130.0], strike=100.0)   # -> array([ 0.,  0., 30.])
-put_payoff([70.0, 100.0, 130.0], strike=100.0)    # -> array([30.,  0.,  0.])
+# ... and an array-like yields a float64 array.
+print(repr(call_payoff([80.0, 100.0, 130.0], strike=100.0)))
+print(repr(put_payoff([70.0, 100.0, 130.0], strike=100.0)))
 
 # call_payoff(100.0, strike=-1.0) raises ValueError: strike must be non-negative
+```
+
+```result
+np.float64(20.0)
+np.float64(20.0)
+array([ 0.,  0., 30.])
+array([30.,  0.,  0.])
 ```
 
 ## Development

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,18 +155,30 @@ coverage_fail_under = 100
 # Keep the two in step.
 pytest-rhiza = "pytest-rhiza==0.2.1"
 
+# Restored after the v1.4.2 bump dropped it. The note that removed it reasoned that the
+# value "is now the CLI's default verbatim, so the entry restated it", and checked that
+# against rhiza-task@0.3.1 -- where it is true. But `RHIZA_TASK` in the Makefile pins
+# 0.1.2 for local `make`, and the default is not the same on both sides:
+#
+#   uvx rhiza-task@0.1.2 print mkdocs_extra_packages  ->  (empty)
+#   uvx rhiza-task@0.3.1 print mkdocs_extra_packages  ->  mkdocstrings[python]
+#
+# So `make book` lost mkdocstrings and died with "mkdocstrings plugin is enabled, but
+# mkdocstrings is not installed" -- mkdocs.yml declares the plugin and docs/api/*.md needs
+# it for the `:::` directives. CI never saw it, because rhiza_book.yml delegates to
+# jebel-quant/rhiza@v1.4.2, which pins its own newer CLI. Green in CI, broken on a laptop.
+#
+# Declaring it explicitly is correct at both pins and immune to the drift: the value equals
+# 0.3.1's default, so naming it changes nothing there, and it supplies what 0.1.2 lacks.
+# The old note's warning still stands and is the reason to keep this list at exactly one
+# entry -- naming the setting *replaces* the default rather than appending to it, so this is
+# the line someone edits to add a package and accidentally drops mkdocstrings from the book
+# build with. Add to it, never overwrite it. See #244.
+mkdocs-extra-packages = ["mkdocstrings[python]"]
+
 # Not set, on purpose. Each of these was checked against rhiza-task@0.3.1 rather than
 # recalled, and this note is here to stop them being re-added:
 #
-#   mkdocs-extra-packages -- was `["mkdocstrings[python]"]` here until the v1.4.2 bump, and
-#                          that is now the CLI's default verbatim, so the entry restated it.
-#                          Naming the setting *replaces* the default list rather than adding
-#                          to it, which makes a redundant entry a liability: it is the line
-#                          someone edits to add a package and accidentally drops
-#                          mkdocstrings from the book build with. docs/api/*.md still needs
-#                          mkdocstrings for its `:::` directives -- it just gets it by
-#                          default now. Verified behaviour-neutral: `print
-#                          mkdocs_extra_packages` returns `mkdocstrings[python]` either way.
 #   marimo-folder        -- the notebooks are in `book/marimo/notebooks/` and the CLI
 #                          defaults to `docs/notebooks`, so this one is a *known* mismatch
 #                          left alone rather than a default agreed with. Setting it would


### PR DESCRIPTION
Closes the three remaining `/rhiza:quality` findings. One commit per issue, each
independently revertable.

All three were **invisible to CI** and reproduced only locally — which is what
they have in common and the reason they survived. Two of them were green in CI
while broken or unmeasured on a laptop.

## `fix(book)`: restore mkdocstrings for the book build — closes #244

`make book` died with `mkdocstrings plugin is enabled, but mkdocstrings is not
installed`. The v1.4.2 bump dropped `mkdocs-extra-packages` from
`[tool.rhiza-task]` on the grounds that the value was "now the CLI's default
verbatim". That was verified against `rhiza-task@0.3.1` and is true there — but
`RHIZA_TASK` pins **0.1.2** for local `make`:

```
uvx rhiza-task@0.1.2 print mkdocs_extra_packages  ->  (empty)
uvx rhiza-task@0.3.1 print mkdocs_extra_packages  ->  mkdocstrings[python]
```

`rhiza_book.yml` delegates to `jebel-quant/rhiza@v1.4.2`, which pins its own
newer CLI, so CI never saw it. This is the version drift documented at the top of
the `Makefile` becoming load-bearing for the first time.

Re-declaring the setting is correct at *both* pins: the value equals 0.3.1's
default, so it changes nothing there, and it supplies what 0.1.2 lacks. Chosen
over bumping `RHIZA_TASK`, which carries the wider blast radius the `Makefile`
warns about — and which the repo's own notes say is a deliberate decision, not a
tidy-up.

The comment that removed the setting is rewritten to say why it is back, keeping
its warning that naming the setting *replaces* the default rather than appending
— the reason the list must stay at exactly one entry.

**Verified:** `[SUCCESS] book built at _book/`, and the recipe now runs
`uvx --with mkdocstrings[python] zensical build`.

## `fix(make)`: stop LICENSE shadowing the `license` task — closes #245

`make license` printed `make: 'license' is up to date` and never ran the copyleft
scan. The names don't match — task `license`, file `LICENSE` — but on a
case-insensitive filesystem make's stat finds `LICENSE` anyway and treats the
target as an up-to-date file.

The part that makes this more than cosmetic: **`make all` depends on `license`**,
so the target documented as "run every gate, as CI does" was reporting success on
macOS with that gate silently skipped. A gate that measures nothing while
printing `ok` is precisely the failure mode the `ci-os-matrix` comment in
`pyproject.toml` already warns about — and `ci-os-matrix` runs all three OSes,
but the only one that could have caught this is ubuntu, where the bug doesn't
reproduce.

Fixed with the pattern this `Makefile` already uses for `book/`, whose comment
explains why both halves are required: `.PHONY` stops make consulting the
filesystem, but it also makes make skip the implicit-rule search, so the
catch-all stops matching and the target becomes "nothing to be done" — the
explicit rule supplies what the catch-all no longer can.

The comment now covers both collisions and records how to find a third.

**Verified:** `make license` runs pip-licenses and reports `ok license`, and
`make all` now lists it among the gates it ran.

## `docs(readme)`: verify the usage examples against their real output — closes #248

The README's Python fences ran clean but asserted nothing — bare expressions with
`# -> value` comments produce no stdout, and there was no ```result``` block to
diff against. Both checkers (the template's `test_readme_validation.py` and
`check_doc_examples.py`) concatenate the python fences, concatenate the
```result``` blocks and compare, so this was empty-against-empty. Executable, but
unverified.

The annotations become `print()` calls and each fence gains a ```result``` block
carrying its real output — captured by running the fences, not transcribed by
hand. `repr()` is used where the type is the point: the scalar-versus-array return
convention is a documented guarantee, `f778fda` fixed a real bug in it, so
`np.float64(20.0)` is the claim worth pinning where plain `20.0` would not be.

**Verified:** `check_doc_examples.py --run` reports `matched: True`, no
violations, no notes.

## Verification

`make all` — the full CI gate set — passes end to end:

```
ok fmt · ok install · ok deps · ok test · ok docs-coverage
ok security · ok license · ok typecheck · ok rhiza-test · ok all
```

plus `make book` → `[SUCCESS]`, 92 tests at 100% coverage, 34 rhiza conformance
checks, and pre-commit clean on each of the three commits.

## Two things noticed but deliberately not changed

- **`make book` now surfaces a real griffe warning** that was unreachable while
  the build was broken: `src/dummypy/grid.py:74: No type or annotation for
  parameter 'n'` / `Parameter 'n' does not appear in the function signature`. It
  is a docstring-versus-signature mismatch in `Grid`, in scope and worth a
  follow-up, but out of scope for #244.
- **`CLAUDE.md:61-62`** still says `make test`, `make fmt` and `make book` "are
  still what CI invokes". They are not — the workflows delegate upstream and the
  `Makefile` header says so plainly. Raised on #249 and still worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
