### PR TITLE
fix: converge local and CI on rhiza-task 0.3.1, and correct the CI claim (#251, #252)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,8 +58,16 @@ across the shim.
 
 ## The developer tasks come from a package, not from make
 
-`make test`, `make fmt`, `make book` and the rest still work, and are still what
-CI invokes. But `Makefile` no longer *contains* them: it is a catch-all that
+`make test`, `make fmt`, `make book` and the rest still work, and are the *human*
+front door. They are **not** what CI invokes: no workflow in this repository runs
+`make` at all. Each one delegates to a `jebel-quant/rhiza` reusable workflow at
+`@v1.4.2`, which pins its own CLI (`rhiza_ci.yml` sets
+`RHIZA_TASK: rhiza-task@0.3.1`) and calls it directly, `uvx "$RHIZA_TASK" test`.
+That pin is deliberately *not* read from this repo — "the gates a build runs must
+not move under it" — so the local `RHIZA_TASK` governs local `make` alone. The
+`Makefile` header carries the full story.
+
+But `Makefile` no longer *contains* the targets either: it is a catch-all that
 forwards every target to
 [`rhiza-task`](https://github.com/jebel-quant/rhiza-task) on PyPI, pinned by the
 one `RHIZA_TASK` variable at the top. That replaced `.rhiza/rhiza.mk` plus ten

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,11 +100,16 @@ Consequences worth knowing:
   flags; call `uvx rhiza-task <task> --flag` (e.g. `--strict`) directly.
 - **Repo-specific targets** go in the `Makefile` itself or in an uncommitted
   `local.mk`; an explicit rule beats the catch-all.
-- Two things the make layer had are gone without replacement: `github.mk`'s
-  seven `gh` wrappers (`gh pr list` is shorter than `make view-prs`) and
-  `docker-build`/`docker-run`/`docker-clean`, which looked for `docker/Dockerfile`
-  while this repo's Dockerfile is at the root — they were already no-ops, as is
-  the `(RHIZA) DOCKER` workflow, which probes the same path.
+- Two things the make layer had were missing at `rhiza-task` 0.1.2 and are back at
+  0.3.1 (#252): `github.mk`'s `gh` wrappers — `view-prs`, `view-issues`, `whoami`,
+  `failed-workflows`, `latest-release`, `workflow-status` — and
+  `docker-build`/`docker-run`/`docker-clean`. 0.3.1 ships 35 tasks that 0.1.2 does
+  not, these among them; `uvx rhiza-task list` is the current answer, not this
+  list. Two caveats survive the bump. The `gh` wrappers remain thin — `gh pr list`
+  is shorter than `make view-prs`. And the docker tasks were no-ops here because
+  they looked for `docker/Dockerfile` while this repo's Dockerfile is at the root;
+  whether 0.3.1 still does is **untested**, and the `(RHIZA) DOCKER` workflow
+  probes the same path regardless.
 
 ### The one remaining make bridge
 
@@ -176,10 +181,20 @@ nothing observable, for the reason given under *Known broken* below.
   [Jebel-Quant/rhiza#1553](https://github.com/Jebel-Quant/rhiza/pull/1553).
   Either way it would newly run those notebooks in CI, which is a change of
   behaviour rather than of configuration; do it deliberately.
-- **The devcontainer bootstrap is broken under `rhiza-task` 0.1.2.**
-  `.devcontainer/bootstrap.sh` exports `UV_SYNC_ARGS="--group test"` and runs
-  `make install`; `rhiza-task` reads that setting as a *string* and splats it
-  character by character into `uv sync - - g r o u p ...`. Only whitespace-free
-  or `;`-separated values survive. CI is unaffected — the devcontainer workflow
-  builds the image without running lifecycle commands — but a human opening the
-  container hits it. The fix belongs in `rhiza-task`'s `_coerce`.
+- ~~**The devcontainer bootstrap is broken under `rhiza-task` 0.1.2.**~~ Fixed by
+  the 0.3.1 bump in #252. `.devcontainer/bootstrap.sh` exports
+  `UV_SYNC_ARGS="--group test"` and runs `make install`; 0.1.2 read that setting
+  as a *string* and splatted it character by character, so only whitespace-free
+  or `;`-separated values survived. 0.3.1's `_coerce` handles it. Verified both
+  ways rather than assumed:
+
+  ```
+  UV_SYNC_ARGS="--group test" uvx rhiza-task@0.1.2 install
+    -> uv sync - - g r o u p   t e s t --inexact --frozen   (uv usage error)
+  UV_SYNC_ARGS="--group test" uvx rhiza-task@0.3.1 install
+    -> uv sync --group test --inexact --frozen
+  ```
+
+  CI was never affected — the devcontainer workflow builds the image without
+  running lifecycle commands — so this only ever bit a human opening the
+  container.

--- a/Makefile
+++ b/Makefile
@@ -18,18 +18,27 @@
 # muscle memory reaches for. Nothing in CI depends on this file any more, with the one
 # unwanted exception noted at the catch-all rule below.
 #
-# RHIZA_TASK is still the entire version contract, but it governs local `make` alone: every
-# workflow pins its own rhiza-task and none of them reads this variable. The two have
-# drifted -- CI is on 0.3.1, this is on 0.1.2 -- so a local `make test` and CI's `test` are
-# no longer the same code. 0.1.2 is also the version whose string-splatting `_coerce` breaks
-# `.devcontainer/bootstrap.sh` (see CLAUDE.md). Bumping it is a deliberate change with its
-# own blast radius, not a tidy-up.
+# RHIZA_TASK is still the entire version contract, and it governs local `make` alone: every
+# workflow pins its own rhiza-task and none of them reads this variable. Upstream is
+# explicit that it must not -- "the gates a build runs must not move under it" -- so the
+# only way for local and CI to agree is for this value to *match* theirs by hand.
+#
+# It now does. `rhiza_ci.yml@v1.4.2` sets `RHIZA_TASK: rhiza-task@0.3.1` and runs every gate
+# as `uvx "$RHIZA_TASK" <task>`, so this pin is that pin, and `make test` is the code CI
+# runs. It was 0.1.2 until #252, and the drift was not cosmetic: the two resolve settings
+# differently, which is what broke `make book` in #244 -- 0.1.2 returns nothing for
+# `mkdocs_extra_packages` where 0.3.1 returns `mkdocstrings[python]`, so the book build lost
+# its docstring handler while CI stayed green. Leaving 0.1.2 also left the string-splatting
+# `_coerce` bug that breaks `.devcontainer/bootstrap.sh` (see CLAUDE.md).
+#
+# Keep this in step with the ref in `.rhiza/template.yml`. A template bump can move the
+# workflow's pin, and nothing local fails when it does -- the symptom is a gate that behaves
+# differently here than in CI, which is exactly the class of bug #244 was.
 #
 # Everything this repo used to say in make variables now lives in `[tool.rhiza-task]` in
-# pyproject.toml -- COVERAGE_FAIL_UNDER as `coverage_fail_under`, while
-# MKDOCS_EXTRA_PACKAGES turned out to restate the CLI's own default and was dropped at the
-# v1.4.2 bump. See CLAUDE.md.
-RHIZA_TASK ?= rhiza-task@0.1.2
+# pyproject.toml -- COVERAGE_FAIL_UNDER as `coverage_fail_under`, and
+# `mkdocs-extra-packages` restored there by #244.
+RHIZA_TASK ?= rhiza-task@0.3.1
 
 # --- The uv bootstrap: no longer a CI bridge, kept as a local convenience ------------------
 #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,10 +155,11 @@ coverage_fail_under = 100
 # Keep the two in step.
 pytest-rhiza = "pytest-rhiza==0.2.1"
 
-# Restored after the v1.4.2 bump dropped it. The note that removed it reasoned that the
-# value "is now the CLI's default verbatim, so the entry restated it", and checked that
-# against rhiza-task@0.3.1 -- where it is true. But `RHIZA_TASK` in the Makefile pins
-# 0.1.2 for local `make`, and the default is not the same on both sides:
+# Restored in #244 after the v1.4.2 bump dropped it, and kept deliberately even though the
+# pins now agree. The note that removed it reasoned that the value "is now the CLI's default
+# verbatim, so the entry restated it" -- true at rhiza-task@0.3.1, which is what it was
+# checked against, but the Makefile pinned 0.1.2 for local `make` at the time and the
+# default was not the same on both sides:
 #
 #   uvx rhiza-task@0.1.2 print mkdocs_extra_packages  ->  (empty)
 #   uvx rhiza-task@0.3.1 print mkdocs_extra_packages  ->  mkdocstrings[python]
@@ -166,14 +167,18 @@ pytest-rhiza = "pytest-rhiza==0.2.1"
 # So `make book` lost mkdocstrings and died with "mkdocstrings plugin is enabled, but
 # mkdocstrings is not installed" -- mkdocs.yml declares the plugin and docs/api/*.md needs
 # it for the `:::` directives. CI never saw it, because rhiza_book.yml delegates to
-# jebel-quant/rhiza@v1.4.2, which pins its own newer CLI. Green in CI, broken on a laptop.
+# jebel-quant/rhiza@v1.4.2, which pins its own CLI. Green in CI, broken on a laptop.
 #
-# Declaring it explicitly is correct at both pins and immune to the drift: the value equals
-# 0.3.1's default, so naming it changes nothing there, and it supplies what 0.1.2 lacks.
+# #252 has since bumped RHIZA_TASK to 0.3.1, so this line is once again equal to the
+# resolved default -- which is precisely the state the v1.4.2 note read as licence to delete
+# it. Do not. The equality holds only while both pins say 0.3.1, and neither of them is
+# pinned here: the workflow's lives upstream and moves with the template ref. Stating the
+# value costs nothing at the current pin and is what makes the book build independent of it.
+#
 # The old note's warning still stands and is the reason to keep this list at exactly one
 # entry -- naming the setting *replaces* the default rather than appending to it, so this is
 # the line someone edits to add a package and accidentally drops mkdocstrings from the book
-# build with. Add to it, never overwrite it. See #244.
+# build with. Add to it, never overwrite it. See #244 and #252.
 mkdocs-extra-packages = ["mkdocstrings[python]"]
 
 # Not set, on purpose. Each of these was checked against rhiza-task@0.3.1 rather than


### PR DESCRIPTION
Closes the two findings from the second `/rhiza:quality` run. Documentation and
two config lines — no source, no test, no workflow changes.

Both are about the same thing from different angles: **CI and local `make` were
not running the same code, and CLAUDE.md said they were.**

## `docs(claude)`: CI does not invoke make — closes #251

CLAUDE.md opened its task-layer section asserting that `make test`, `make fmt` and
`make book` "are still what CI invokes". Nothing in this repo runs make in CI:

```
$ grep -rln 'make ' .github/workflows/
(no output)
```

Every workflow delegates to a `jebel-quant/rhiza` reusable workflow at `@v1.4.2`.
The `Makefile` header already stated this correctly ("Nothing in CI depends on this
file any more"), so the two files contradicted each other on the most load-bearing
fact about how the gates run — and CLAUDE.md is what a newcomer reads first.
`make book` was also named as working when #244 had it failing outright.

## `fix(make)`: pin rhiza-task to 0.3.1 so local matches CI — closes #252

**The CI pin was read from upstream, not assumed.** `rhiza_ci.yml@v1.4.2` line 40:

```yaml
env:
  RHIZA_TASK: rhiza-task@0.3.1
```

and every gate step runs `uvx "$RHIZA_TASK" <task>`. Local `make` was on `0.1.2`.

The drift was not cosmetic — the two resolve settings differently:

```
uvx rhiza-task@0.1.2 print mkdocs_extra_packages  ->  (empty)
uvx rhiza-task@0.3.1 print mkdocs_extra_packages  ->  mkdocstrings[python]
```

That is exactly what broke `make book` in #244 while CI stayed green. #244 fixed
the symptom; this removes the cause.

Upstream pins its side deliberately and will not read a consumer's `RHIZA_TASK` —
*"the gates a build runs must not move under it"* — so convergence can only happen
by this repo matching that value by hand. A pin, not a range, and the comment says
to keep it in step with the template ref.

### Fixed as a side effect, verified both ways

The devcontainer bootstrap. `.devcontainer/bootstrap.sh` exports
`UV_SYNC_ARGS="--group test"`, and 0.1.2's `_coerce` splatted it:

```
UV_SYNC_ARGS="--group test" uvx rhiza-task@0.1.2 install
  -> uv sync - - g r o u p   t e s t --inexact --frozen    (uv usage error)
UV_SYNC_ARGS="--group test" uvx rhiza-task@0.3.1 install
  -> uv sync --group test --inexact --frozen
```

So CLAUDE.md's *Known broken* entry for it is resolved rather than restated. I ran
the 0.1.2 case too rather than trusting the existing note.

### A correction I made to my own issue

#252's body claimed `complexity` and `docs-examples` "exist at 0.3.1 and are absent
at 0.1.2". **Wrong** — they are in neither, being newer than both. That came from a
bare `uvx rhiza-task list`, which resolves to *latest*, not to either pin.
[Corrected on the issue](https://github.com/markrichardson/dummyrepo/issues/252#issuecomment-5378802070).
The core finding stands on the two verified facts above.

The task sets do differ, just not that way: 0.3.1 ships **35 tasks 0.1.2 lacks**,
including `docker-build`/`docker-run`/`docker-clean` and the `gh` wrappers — which
CLAUDE.md called "gone without replacement". That passage is corrected here, with
the caveats that survive the bump kept and the untested one **marked untested**
rather than quietly asserted.

### `mkdocs-extra-packages` kept on purpose

It now equals the resolved default again — which is precisely the state the v1.4.2
note read as licence to delete it, causing #244. The equality holds only while both
pins say 0.3.1, and the workflow's pin lives upstream and moves with the template
ref. The comment explains why it stays.

## Verification at the new pin

`make all` green end to end:

```
ok fmt · ok install · ok deps · ok test · ok docs-coverage
ok security · ok license · ok typecheck · ok rhiza-test · ok all
```

plus `make book` → `[SUCCESS] book built at _book/`, `make semgrep` 0 findings,
92 tests at 100% coverage, 34 conformance checks, and pre-commit clean on both
commits.

## Blast radius

`Makefile:21-31` warned that bumping this pin "is a deliberate change with its own
blast radius, not a tidy-up" — so every gate was re-run at 0.3.1 rather than
assumed, and the venv was restored after the `install` experiments above. The
remaining risk is that 0.3.1 changes a task's behaviour in a way no gate here
exercises; the surface is small, since the gates above are what CI runs and CI has
been on 0.3.1 all along. In effect this brings local *up to* what CI already
validated, rather than moving both to something new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
